### PR TITLE
Add .claude to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ target
 /doc/*.aux
 /doc/*.log
 /doc/*.synctex.gz
+/.claude


### PR DESCRIPTION
## Summary
- Add `.claude` directory to `.gitignore` to prevent session files from being tracked