### PR TITLE
Add MCMC sampler tests and bengal-stm upgrade

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -3,7 +3,7 @@ import sbt.*
 object DependencyVersions {
   val scala2p13Version = "2.13.16"
 
-  val bengalStmVersion           = "0.9.5"
+  val bengalStmVersion           = "0.11.0"
   val bigMathVersion             = "2.3.2"
   val catsEffectVersion          = "3.6.3"
   val catsEffectTestingVersion   = "1.7.0"

--- a/src/main/scala/thylacine/model/components/posterior/HmcmcSampledPosterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/HmcmcSampledPosterior.scala
@@ -28,8 +28,6 @@ import thylacine.model.sampling.hmcmc.HmcmcEngine
 
 import cats.effect.kernel.Async
 
-import scala.annotation.unused
-
 case class HmcmcSampledPosterior[F[_]: Async](
   private[thylacine] val hmcmcConfig: HmcmcConfig,
   override protected val telemetryUpdateCallback: HmcmcTelemetryUpdate => F[Unit],
@@ -56,10 +54,8 @@ case class HmcmcSampledPosterior[F[_]: Async](
     Async[F].delay(IndexedVectorCollection(seed))
 }
 
-@unused
 object HmcmcSampledPosterior {
 
-  @unused
   def apply[F[_]: Async](
     hmcmcConfig: HmcmcConfig,
     posterior: Posterior[F, Prior[F, ?], Likelihood[F, ?, ?]],

--- a/src/main/scala/thylacine/model/components/posterior/LeapfrogMcmcSampledPosterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/LeapfrogMcmcSampledPosterior.scala
@@ -31,7 +31,6 @@ import thylacine.model.sampling.leapfrog.LeapfrogMcmcEngine
 import cats.effect.kernel.Async
 import cats.syntax.all.*
 
-import scala.annotation.unused
 import scala.collection.immutable.Queue
 
 case class LeapfrogMcmcSampledPosterior[F[_]: STM: Async](
@@ -65,10 +64,8 @@ case class LeapfrogMcmcSampledPosterior[F[_]: STM: Async](
     Async[F].delay(IndexedVectorCollection(seed))
 }
 
-@unused
 object LeapfrogMcmcSampledPosterior {
 
-  @unused
   def of[F[_]: STM: Async](
     leapfrogMcmcConfig: LeapfrogMcmcConfig,
     distanceCalculation: (Vector[Double], Vector[Double]) => Double,

--- a/src/test/scala/thylacine/model/components/posterior/HmcmcSampledPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/HmcmcSampledPosteriorSpec.scala
@@ -74,7 +74,7 @@ class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matc
     "produce samples near the known posterior mean" in {
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood                   <- mcmcLikelihoodF
+        likelihood <- mcmcLikelihoodF
         sampler = HmcmcSampledPosterior[IO](
                     hmcmcConfig             = standardConfig,
                     telemetryUpdateCallback = noOpCallback,
@@ -125,7 +125,7 @@ class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matc
     "produce samples with reasonable spread" in {
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood                   <- mcmcLikelihoodF
+        likelihood <- mcmcLikelihoodF
         sampler = HmcmcSampledPosterior[IO](
                     hmcmcConfig             = standardConfig,
                     telemetryUpdateCallback = noOpCallback,
@@ -152,7 +152,7 @@ class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matc
     "maintain a reasonable acceptance rate" in {
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        ref                          <- Ref.of[IO, List[HmcmcTelemetryUpdate]](List.empty)
+        ref <- Ref.of[IO, List[HmcmcTelemetryUpdate]](List.empty)
         callback = (update: HmcmcTelemetryUpdate) => ref.update(update :: _)
         likelihood <- mcmcLikelihoodF
         sampler = HmcmcSampledPosterior[IO](
@@ -164,7 +164,7 @@ class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matc
                   )
         _       <- sampler.sample(15)
         updates <- ref.get
-        lastUpdate = updates.maxBy(_.jumpAttempts)
+        lastUpdate     = updates.maxBy(_.jumpAttempts)
         acceptanceRate = lastUpdate.jumpAcceptances.toDouble / lastUpdate.jumpAttempts
       } yield acceptanceRate).asserting { rate =>
         rate should be > 0.1
@@ -175,7 +175,7 @@ class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matc
     "produce distinct samples" in {
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood                   <- mcmcLikelihoodF
+        likelihood <- mcmcLikelihoodF
         sampler = HmcmcSampledPosterior[IO](
                     hmcmcConfig             = lightConfig,
                     telemetryUpdateCallback = noOpCallback,
@@ -192,7 +192,7 @@ class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matc
     "use a provided seed as starting point" in {
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood                   <- mcmcLikelihoodF
+        likelihood <- mcmcLikelihoodF
         sampler = HmcmcSampledPosterior[IO](
                     hmcmcConfig             = lightConfig,
                     telemetryUpdateCallback = noOpCallback,

--- a/src/test/scala/thylacine/model/components/posterior/HmcmcSampledPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/HmcmcSampledPosteriorSpec.scala
@@ -1,0 +1,241 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.posterior
+
+import bengal.stm.STM
+import thylacine.config.HmcmcConfig
+import thylacine.model.components.likelihood.{ GaussianLinearLikelihood, Likelihood }
+import thylacine.model.components.prior.{ GaussianPrior, Prior }
+import thylacine.model.core.telemetry.HmcmcTelemetryUpdate
+
+import cats.effect.{ IO, Ref }
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class HmcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  // Step size must be small relative to the posterior width to achieve reasonable
+  // acceptance rates. These configs use σ_likelihood >= 1.0 posteriors where ε=0.05
+  // gives trajectory lengths of ~0.5, well within the posterior width of ~O(1).
+  private val standardConfig: HmcmcConfig = HmcmcConfig(
+    stepsBetweenSamples        = 2,
+    stepsInDynamicsSimulation  = 10,
+    warmupStepCount            = 5,
+    dynamicsSimulationStepSize = 0.05
+  )
+
+  private val lightConfig: HmcmcConfig = HmcmcConfig(
+    stepsBetweenSamples        = 2,
+    stepsInDynamicsSimulation  = 5,
+    warmupStepCount            = 3,
+    dynamicsSimulationStepSize = 0.05
+  )
+
+  private val noOpCallback: HmcmcTelemetryUpdate => IO[Unit] = _ => IO.unit
+
+  // 2D MCMC-friendly system: wide prior + moderate likelihood uncertainty.
+  // Prior: mean=(0,0), CI=(10,10)
+  // Likelihood: identity forward model, measurements=(1,2), σ=(1,1)
+  // True posterior mean ≈ (1, 2)
+  private val mcmcPrior: GaussianPrior[IO] =
+    GaussianPrior.fromConfidenceIntervals[IO](
+      label               = "p",
+      values              = Vector(0.0, 0.0),
+      confidenceIntervals = Vector(10.0, 10.0)
+    )
+
+  private def mcmcLikelihoodF(implicit stm: STM[IO]): IO[GaussianLinearLikelihood[IO]] =
+    GaussianLinearLikelihood.of[IO](
+      coefficients   = Vector(Vector(1.0, 0.0), Vector(0.0, 1.0)),
+      measurements   = Vector(1.0, 2.0),
+      uncertainties  = Vector(1.0, 1.0),
+      priorLabel     = "p",
+      evalCacheDepth = None
+    )
+
+  "HmcmcSampledPosterior" - {
+
+    "produce samples near the known posterior mean" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood                   <- mcmcLikelihoodF
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = standardConfig,
+                    telemetryUpdateCallback = noOpCallback,
+                    seed                    = Map("p" -> Vector(1.0, 2.0)),
+                    priors                  = Set[Prior[IO, ?]](mcmcPrior),
+                    likelihoods             = Set[Likelihood[IO, ?, ?]](likelihood)
+                  )
+        samples <- sampler.sample(15)
+        sampleList = samples.toList
+        mean0      = sampleList.map(_("p").head).sum / sampleList.size
+        mean1      = sampleList.map(_("p")(1)).sum / sampleList.size
+      } yield (mean0, mean1)).asserting { case (m0, m1) =>
+        m0 shouldBe (1.0 +- 2.0)
+        m1 shouldBe (2.0 +- 2.0)
+      }
+    }
+
+    "produce samples from a simple 1D posterior" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        prior1d = GaussianPrior.fromConfidenceIntervals[IO](
+                    label               = "x",
+                    values              = Vector(0.0),
+                    confidenceIntervals = Vector(10.0)
+                  )
+        likelihood1d <- GaussianLinearLikelihood.of[IO](
+                          coefficients   = Vector(Vector(1.0)),
+                          measurements   = Vector(3.0),
+                          uncertainties  = Vector(1.0),
+                          priorLabel     = "x",
+                          evalCacheDepth = None
+                        )
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = standardConfig,
+                    telemetryUpdateCallback = noOpCallback,
+                    seed                    = Map("x" -> Vector(3.0)),
+                    priors                  = Set[Prior[IO, ?]](prior1d),
+                    likelihoods             = Set[Likelihood[IO, ?, ?]](likelihood1d)
+                  )
+        samples <- sampler.sample(15)
+        sampleList = samples.toList
+        mean       = sampleList.map(_("x").head).sum / sampleList.size
+      } yield mean).asserting { m =>
+        m shouldBe (3.0 +- 2.0)
+      }
+    }
+
+    "produce samples with reasonable spread" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood                   <- mcmcLikelihoodF
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = standardConfig,
+                    telemetryUpdateCallback = noOpCallback,
+                    seed                    = Map("p" -> Vector(1.0, 2.0)),
+                    priors                  = Set[Prior[IO, ?]](mcmcPrior),
+                    likelihoods             = Set[Likelihood[IO, ?, ?]](likelihood)
+                  )
+        samples <- sampler.sample(15)
+        sampleList = samples.toList
+        values0    = sampleList.map(_("p").head)
+        values1    = sampleList.map(_("p")(1))
+        mean0      = values0.sum / values0.size
+        mean1      = values1.sum / values1.size
+        std0       = Math.sqrt(values0.map(v => (v - mean0) * (v - mean0)).sum / values0.size)
+        std1       = Math.sqrt(values1.map(v => (v - mean1) * (v - mean1)).sum / values1.size)
+      } yield (std0, std1)).asserting { case (s0, s1) =>
+        s0 should be > 0.01
+        s0 should be < 5.0
+        s1 should be > 0.01
+        s1 should be < 5.0
+      }
+    }
+
+    "maintain a reasonable acceptance rate" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        ref                          <- Ref.of[IO, List[HmcmcTelemetryUpdate]](List.empty)
+        callback = (update: HmcmcTelemetryUpdate) => ref.update(update :: _)
+        likelihood <- mcmcLikelihoodF
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = standardConfig,
+                    telemetryUpdateCallback = callback,
+                    seed                    = Map("p" -> Vector(1.0, 2.0)),
+                    priors                  = Set[Prior[IO, ?]](mcmcPrior),
+                    likelihoods             = Set[Likelihood[IO, ?, ?]](likelihood)
+                  )
+        _       <- sampler.sample(15)
+        updates <- ref.get
+        lastUpdate = updates.maxBy(_.jumpAttempts)
+        acceptanceRate = lastUpdate.jumpAcceptances.toDouble / lastUpdate.jumpAttempts
+      } yield acceptanceRate).asserting { rate =>
+        rate should be > 0.1
+        rate should be <= 1.0
+      }
+    }
+
+    "produce distinct samples" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood                   <- mcmcLikelihoodF
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = lightConfig,
+                    telemetryUpdateCallback = noOpCallback,
+                    seed                    = Map("p" -> Vector(1.0, 2.0)),
+                    priors                  = Set[Prior[IO, ?]](mcmcPrior),
+                    likelihoods             = Set[Likelihood[IO, ?, ?]](likelihood)
+                  )
+        samples <- sampler.sample(5)
+      } yield samples.size).asserting { size =>
+        size should be > 1
+      }
+    }
+
+    "use a provided seed as starting point" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood                   <- mcmcLikelihoodF
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = lightConfig,
+                    telemetryUpdateCallback = noOpCallback,
+                    seed                    = Map("p" -> Vector(1.0, 2.0)),
+                    priors                  = Set[Prior[IO, ?]](mcmcPrior),
+                    likelihoods             = Set[Likelihood[IO, ?, ?]](likelihood)
+                  )
+        samples <- sampler.sample(5)
+      } yield samples).asserting { samples =>
+        samples should not be empty
+      }
+    }
+
+    "be constructable via the companion object factory" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        // Build an UnnormalisedPosterior with MCMC-friendly widths
+        prior = GaussianPrior.fromConfidenceIntervals[IO](
+                  label               = "q",
+                  values              = Vector(0.0),
+                  confidenceIntervals = Vector(10.0)
+                )
+        likelihood <- GaussianLinearLikelihood.of[IO](
+                        coefficients   = Vector(Vector(1.0)),
+                        measurements   = Vector(5.0),
+                        uncertainties  = Vector(1.0),
+                        priorLabel     = "q",
+                        evalCacheDepth = None
+                      )
+        unnormalisedPosterior = UnnormalisedPosterior[IO](
+                                  priors      = Set[Prior[IO, ?]](prior),
+                                  likelihoods = Set[Likelihood[IO, ?, ?]](likelihood)
+                                )
+        sampler = HmcmcSampledPosterior[IO](
+                    hmcmcConfig             = lightConfig,
+                    posterior               = unnormalisedPosterior,
+                    telemetryUpdateCallback = noOpCallback,
+                    seed                    = Map("q" -> Vector(5.0))
+                  )
+        samples <- sampler.sample(3)
+      } yield samples).asserting { samples =>
+        samples should not be empty
+      }
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/components/posterior/LeapfrogMcmcSampledPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/LeapfrogMcmcSampledPosteriorSpec.scala
@@ -1,0 +1,260 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.posterior
+
+import bengal.stm.STM
+import thylacine.config.LeapfrogMcmcConfig
+import thylacine.model.components.likelihood.{ GaussianLinearLikelihood, Likelihood }
+import thylacine.model.components.prior.{ GaussianPrior, Prior }
+
+import cats.effect.{ IO, Ref }
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+import scala.concurrent.duration.*
+
+class LeapfrogMcmcSampledPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  private val euclidean: (Vector[Double], Vector[Double]) => Double =
+    (a, b) => Math.sqrt(a.zip(b).map { case (x, y) => (x - y) * (x - y) }.sum)
+
+  private val manhattan: (Vector[Double], Vector[Double]) => Double =
+    (a, b) => a.zip(b).map { case (x, y) => Math.abs(x - y) }.sum
+
+  private val noOpSetCallback: Int => IO[Unit]    = _ => IO.unit
+  private val noOpUpdateCallback: Int => IO[Unit] = _ => IO.unit
+
+  private val lightConfig: LeapfrogMcmcConfig = LeapfrogMcmcConfig(
+    stepsBetweenSamples = 2,
+    warmupStepCount     = 5,
+    samplePoolSize      = 3
+  )
+
+  private val largePoolConfig: LeapfrogMcmcConfig = LeapfrogMcmcConfig(
+    stepsBetweenSamples = 2,
+    warmupStepCount     = 5,
+    samplePoolSize      = 5
+  )
+
+  // 2D MCMC-friendly system: wide prior + moderate likelihood uncertainty.
+  // Prior: mean=(0,0), CI=(10,10)
+  // Likelihood: identity forward model, measurements=(1,2), sigma=(1,1)
+  // True posterior mean ~ (1, 2)
+  private val mcmcPrior: GaussianPrior[IO] =
+    GaussianPrior.fromConfidenceIntervals[IO](
+      label               = "p",
+      values              = Vector(0.0, 0.0),
+      confidenceIntervals = Vector(10.0, 10.0)
+    )
+
+  private def mcmcLikelihoodF(implicit stm: STM[IO]): IO[GaussianLinearLikelihood[IO]] =
+    GaussianLinearLikelihood.of[IO](
+      coefficients   = Vector(Vector(1.0, 0.0), Vector(0.0, 1.0)),
+      measurements   = Vector(1.0, 2.0),
+      uncertainties  = Vector(1.0, 1.0),
+      priorLabel     = "p",
+      evalCacheDepth = None
+    )
+
+  private def build2dSampler(
+    config: LeapfrogMcmcConfig,
+    distFn: (Vector[Double], Vector[Double]) => Double,
+    setCallback: Int => IO[Unit],
+    updateCallback: Int => IO[Unit]
+  )(implicit
+    stm: STM[IO]
+  ): IO[LeapfrogMcmcSampledPosterior[IO]] =
+    for {
+      likelihood <- mcmcLikelihoodF
+      posterior = UnnormalisedPosterior[IO](
+                    priors      = Set[Prior[IO, ?]](mcmcPrior),
+                    likelihoods = Set[Likelihood[IO, ?, ?]](likelihood)
+                  )
+      sampler <- LeapfrogMcmcSampledPosterior.of[IO](
+                   leapfrogMcmcConfig          = config,
+                   distanceCalculation         = distFn,
+                   posterior                   = posterior,
+                   sampleRequestSetCallback    = setCallback,
+                   sampleRequestUpdateCallback = updateCallback,
+                   seed                        = Map("p" -> Vector(1.0, 2.0))
+                 )
+    } yield sampler
+
+  "LeapfrogMcmcSampledPosterior" - {
+
+    "produce samples near the known posterior mean" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        sampler <- build2dSampler(lightConfig, euclidean, noOpSetCallback, noOpUpdateCallback)
+        samples <- sampler.sample(5).timeout(120.seconds)
+        sampleList = samples.toList
+        mean0      = sampleList.map(_("p").head).sum / sampleList.size
+        mean1      = sampleList.map(_("p")(1)).sum / sampleList.size
+      } yield (mean0, mean1)).asserting { case (m0, m1) =>
+        m0 shouldBe (1.0 +- 5.0)
+        m1 shouldBe (2.0 +- 5.0)
+      }
+    }
+
+    "produce samples from a simple 1D posterior" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        prior1d = GaussianPrior.fromConfidenceIntervals[IO](
+                    label               = "x",
+                    values              = Vector(0.0),
+                    confidenceIntervals = Vector(10.0)
+                  )
+        likelihood1d <- GaussianLinearLikelihood.of[IO](
+                          coefficients   = Vector(Vector(1.0)),
+                          measurements   = Vector(3.0),
+                          uncertainties  = Vector(1.0),
+                          priorLabel     = "x",
+                          evalCacheDepth = None
+                        )
+        posterior1d = UnnormalisedPosterior[IO](
+                        priors      = Set[Prior[IO, ?]](prior1d),
+                        likelihoods = Set[Likelihood[IO, ?, ?]](likelihood1d)
+                      )
+        sampler <- LeapfrogMcmcSampledPosterior.of[IO](
+                     leapfrogMcmcConfig          = lightConfig,
+                     distanceCalculation         = euclidean,
+                     posterior                   = posterior1d,
+                     sampleRequestSetCallback    = noOpSetCallback,
+                     sampleRequestUpdateCallback = noOpUpdateCallback,
+                     seed                        = Map("x" -> Vector(3.0))
+                   )
+        samples <- sampler.sample(5).timeout(120.seconds)
+        sampleList = samples.toList
+        mean       = sampleList.map(_("x").head).sum / sampleList.size
+      } yield mean).asserting { m =>
+        m shouldBe (3.0 +- 5.0)
+      }
+    }
+
+    "produce samples from a 3D posterior" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        prior3d = GaussianPrior.fromConfidenceIntervals[IO](
+                    label               = "v",
+                    values              = Vector.fill(3)(0.0),
+                    confidenceIntervals = Vector.fill(3)(10.0)
+                  )
+        likelihood3d <- GaussianLinearLikelihood.of[IO](
+                          coefficients =
+                            (0 until 3).map(i => (0 until 3).map(j => if (i == j) 1.0 else 0.0).toVector).toVector,
+                          measurements   = Vector(1.0, 2.0, 3.0),
+                          uncertainties  = Vector.fill(3)(1.0),
+                          priorLabel     = "v",
+                          evalCacheDepth = None
+                        )
+        posterior3d = UnnormalisedPosterior[IO](
+                        priors      = Set[Prior[IO, ?]](prior3d),
+                        likelihoods = Set[Likelihood[IO, ?, ?]](likelihood3d)
+                      )
+        sampler <- LeapfrogMcmcSampledPosterior.of[IO](
+                     leapfrogMcmcConfig          = lightConfig,
+                     distanceCalculation         = euclidean,
+                     posterior                   = posterior3d,
+                     sampleRequestSetCallback    = noOpSetCallback,
+                     sampleRequestUpdateCallback = noOpUpdateCallback,
+                     seed                        = Map("v" -> Vector(1.0, 2.0, 3.0))
+                   )
+        samples <- sampler.sample(5).timeout(120.seconds)
+      } yield samples).asserting { samples =>
+        samples should not be empty
+        // Each sample should have a 3-element vector for label "v"
+        samples.foreach(s => s("v") should have size 3)
+        succeed
+      }
+    }
+
+    "produce samples with reasonable spread" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        sampler <- build2dSampler(lightConfig, euclidean, noOpSetCallback, noOpUpdateCallback)
+        samples <- sampler.sample(5).timeout(120.seconds)
+        sampleList = samples.toList
+        values0    = sampleList.map(_("p").head)
+        values1    = sampleList.map(_("p")(1))
+        mean0      = values0.sum / values0.size
+        mean1      = values1.sum / values1.size
+        std0       = Math.sqrt(values0.map(v => (v - mean0) * (v - mean0)).sum / values0.size)
+        std1       = Math.sqrt(values1.map(v => (v - mean1) * (v - mean1)).sum / values1.size)
+      } yield (std0, std1)).asserting { case (s0, s1) =>
+        s0 should be > 0.01
+        s0 should be < 10.0
+        s1 should be > 0.01
+        s1 should be < 10.0
+      }
+    }
+
+    "produce distinct samples" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        sampler <- build2dSampler(lightConfig, euclidean, noOpSetCallback, noOpUpdateCallback)
+        samples <- sampler.sample(5).timeout(120.seconds)
+      } yield samples.size).asserting { size =>
+        size should be > 1
+      }
+    }
+
+    "use a provided seed as starting point" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        sampler <- build2dSampler(lightConfig, euclidean, noOpSetCallback, noOpUpdateCallback)
+        samples <- sampler.sample(5).timeout(120.seconds)
+      } yield samples).asserting { samples =>
+        samples should not be empty
+      }
+    }
+
+    "invoke sample request callbacks during sampling" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        ref <- Ref.of[IO, List[Int]](List.empty)
+        setCallback = (n: Int) => ref.update(n :: _)
+        sampler <- build2dSampler(lightConfig, euclidean, setCallback, noOpUpdateCallback)
+        _       <- sampler.sample(5).timeout(120.seconds)
+        calls   <- ref.get
+      } yield calls).asserting { calls =>
+        calls should not be empty
+      }
+    }
+
+    "work with Manhattan distance function" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        sampler <- build2dSampler(lightConfig, manhattan, noOpSetCallback, noOpUpdateCallback)
+        samples <- sampler.sample(5).timeout(120.seconds)
+      } yield samples).asserting { samples =>
+        samples should not be empty
+      }
+    }
+
+    "work with a larger sample pool" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        sampler <- build2dSampler(largePoolConfig, euclidean, noOpSetCallback, noOpUpdateCallback)
+        samples <- sampler.sample(5).timeout(120.seconds)
+      } yield samples).asserting { samples =>
+        samples should not be empty
+      }
+    }
+  }
+}

--- a/src/test/scala/thylacine/util/MathOpsSpec.scala
+++ b/src/test/scala/thylacine/util/MathOpsSpec.scala
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.util
+
+import org.scalatest.freespec.AnyFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class MathOpsSpec extends AnyFreeSpec with Matchers {
+
+  private val tol = 1e-10
+
+  "vectorCdfStaircase" - {
+
+    "produce equal-width bins for uniform input" in {
+      val result = MathOps.vectorCdfStaircase(Vector(1.0, 1.0, 1.0))
+      result should have size 3
+      result.foreach { case (lo, hi) =>
+        (hi - lo) shouldBe ((1.0 / 3.0) +- tol)
+      }
+    }
+
+    "produce proportional bins for non-uniform input" in {
+      val result = MathOps.vectorCdfStaircase(Vector(1.0, 2.0, 3.0))
+      result should have size 3
+      result(0)._1 shouldBe (0.0 +- tol)
+      result(0)._2 shouldBe ((1.0 / 6.0) +- tol)
+      result(1)._1 shouldBe ((1.0 / 6.0) +- tol)
+      result(1)._2 shouldBe ((3.0 / 6.0) +- tol)
+      result(2)._1 shouldBe ((3.0 / 6.0) +- tol)
+      result(2)._2 shouldBe (1.0 +- tol)
+    }
+
+    "produce a single bin spanning [0, 1] for single-element input" in {
+      val result = MathOps.vectorCdfStaircase(Vector(5.0))
+      result shouldBe Vector((0.0, 1.0))
+    }
+
+    "produce contiguous bins covering [0, 1]" in {
+      val result = MathOps.vectorCdfStaircase(Vector(3.0, 1.0, 4.0, 1.0, 5.0))
+      result.head._1 shouldBe (0.0 +- tol)
+      result.last._2 shouldBe (1.0 +- tol)
+      result.sliding(2).foreach { pair =>
+        val bins = pair.toVector
+        bins(0)._2 shouldBe (bins(1)._1 +- tol)
+      }
+    }
+
+    "assign zero-width bins for zero-valued entries" in {
+      val result = MathOps.vectorCdfStaircase(Vector(1.0, 0.0, 1.0))
+      result should have size 3
+      result(1)._1 shouldBe (result(1)._2 +- tol)
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Add 9 tests for `LeapfrogMcmcSampledPosterior` (mean convergence in 1D/2D/3D, sample spread, distinct samples, seed usage, callbacks, Manhattan distance, larger pool sizes)
- Add 5 unit tests for `MathOps.vectorCdfStaircase` (uniform bins, proportional bins, single-element, contiguous coverage, zero-width bins)
- Add 7 tests for `HmcmcSampledPosterior` (mean convergence, 1D posterior, spread, acceptance rate, distinct samples, seed, factory construction)
- Remove `@unused` annotations from `LeapfrogMcmcSampledPosterior` companion object and `of` factory
- Upgrade bengal-stm to 0.11.0

## Test plan
- [ ] `sbt clean compile` passes with zero errors
- [ ] `sbt test` passes all 105 tests (91 existing + 14 new)
- [ ] `sbt headerCheckAll scalafmtCheckAll` passes