### PR TITLE
Fix Cauchy gradient sign error and add numerical computation tests

### DIFF
--- a/src/main/scala/thylacine/model/distributions/CauchyDistribution.scala
+++ b/src/main/scala/thylacine/model/distributions/CauchyDistribution.scala
@@ -65,7 +65,7 @@ private[thylacine] case class CauchyDistribution(
   ): VectorContainer = {
     val differentialFromMean = input.rawVector.zip(mean.rawVector).map { case (i, m) => i - m }
     val quadForm             = LinearAlgebra.quadraticForm(differentialFromMean, rawInverseCovariance)
-    val multiplierResult     = (1 + domainDimension) / (1 + quadForm)
+    val multiplierResult     = -(1.0 + domainDimension) / (1 + quadForm)
     val vectorResult         = LinearAlgebra.multiplyMV(rawInverseCovariance, differentialFromMean)
 
     VectorContainer(vectorResult.map(_ * multiplierResult))

--- a/src/test/scala/thylacine/model/components/forwardmodel/LinearForwardModelSpec.scala
+++ b/src/test/scala/thylacine/model/components/forwardmodel/LinearForwardModelSpec.scala
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.forwardmodel
+
+import bengal.stm.STM
+import thylacine.TestUtils.*
+import thylacine.model.core.GenericIdentifier.*
+import thylacine.model.core.values.{ IndexedMatrixCollection, IndexedVectorCollection, VectorContainer }
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class LinearForwardModelSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+  "LinearForwardModel" - {
+
+    "evaluate A*x correctly" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- LinearForwardModel.of[IO](
+                   label          = "p",
+                   values         = Vector(Vector(1.0, 3.0), Vector(2.0, 4.0)),
+                   evalCacheDepth = None
+                 )
+        result <- model.evalAt(IndexedVectorCollection(Map("p" -> Vector(1.0, 2.0))))
+      } yield maxVectorDiff(result.scalaVector, Vector(7.0, 10.0)))
+        .asserting(_ shouldBe (0.0 +- 1e-10))
+    }
+
+    "evaluate A*x + b correctly with offset" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- LinearForwardModel.of[IO](
+                   transform = IndexedMatrixCollection(
+                     ModelParameterIdentifier("p"),
+                     Vector(Vector(1.0, 0.0), Vector(0.0, 1.0))
+                   ),
+                   vectorOffset   = Some(VectorContainer(Vector(1.0, 2.0))),
+                   evalCacheDepth = None
+                 )
+        result <- model.evalAt(IndexedVectorCollection(Map("p" -> Vector(3.0, 4.0))))
+      } yield maxVectorDiff(result.scalaVector, Vector(4.0, 6.0)))
+        .asserting(_ shouldBe (0.0 +- 1e-10))
+    }
+
+    "return the transform matrix as the Jacobian" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- LinearForwardModel.of[IO](
+                   label          = "p",
+                   values         = Vector(Vector(1.0, 3.0), Vector(2.0, 4.0)),
+                   evalCacheDepth = None
+                 )
+        jac <- model.jacobianAt(IndexedVectorCollection(Map("p" -> Vector(99.0, -42.0))))
+      } yield jac.genericScalaRepresentation)
+        .asserting(_ shouldBe Map("p" -> Vector(Vector(1.0, 3.0), Vector(2.0, 4.0))))
+    }
+
+    "handle multi-block parameters" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- LinearForwardModel.of[IO](
+                   transform = IndexedMatrixCollection(
+                     Map(
+                       ModelParameterIdentifier("a") -> thylacine.model.core.values
+                         .MatrixContainer(Vector(Vector(1.0), Vector(0.0))),
+                       ModelParameterIdentifier("b") -> thylacine.model.core.values
+                         .MatrixContainer(Vector(Vector(0.0), Vector(1.0)))
+                     )
+                   ),
+                   vectorOffset   = None,
+                   evalCacheDepth = None
+                 )
+        result <- model.evalAt(IndexedVectorCollection(Map("a" -> Vector(3.0), "b" -> Vector(4.0))))
+        jac    <- model.jacobianAt(IndexedVectorCollection(Map("a" -> Vector(3.0), "b" -> Vector(4.0))))
+      } yield (result.scalaVector, jac.genericScalaRepresentation))
+        .asserting { case (eval, jac) =>
+          maxVectorDiff(eval, Vector(3.0, 4.0)) shouldBe (0.0 +- 1e-10)
+          jac("a") shouldBe Vector(Vector(1.0), Vector(0.0))
+          jac("b") shouldBe Vector(Vector(0.0), Vector(1.0))
+        }
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/components/forwardmodel/NonLinearForwardModelSpec.scala
+++ b/src/test/scala/thylacine/model/components/forwardmodel/NonLinearForwardModelSpec.scala
@@ -1,0 +1,97 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.forwardmodel
+
+import bengal.stm.STM
+import thylacine.TestUtils.*
+import thylacine.model.core.values.IndexedVectorCollection
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class NonLinearForwardModelSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  // f(x1, x2) = [x1^2, x1*x2]
+  private val nonlinearEval: Map[String, Vector[Double]] => Vector[Double] = { input =>
+    val x = input("x")
+    Vector(x(0) * x(0), x(0) * x(1))
+  }
+
+  // J(x1, x2) = [[2*x1, 0], [x2, x1]]
+  private val analyticJacobian: Map[String, Vector[Double]] => Map[String, Vector[Vector[Double]]] = { input =>
+    val x = input("x")
+    Map("x" -> Vector(Vector(2 * x(0), 0.0), Vector(x(1), x(0))))
+  }
+
+  "NonLinearForwardModel" - {
+
+    "evaluate a nonlinear function correctly" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- NonLinearForwardModel.of[IO](
+                   evaluation         = nonlinearEval,
+                   differential       = 1e-7,
+                   domainDimensions   = Map("x" -> 2),
+                   rangeDimension     = 2,
+                   evalCacheDepth     = None,
+                   jacobianCacheDepth = None
+                 )
+        result <- model.evalAt(IndexedVectorCollection(Map("x" -> Vector(2.0, 3.0))))
+      } yield maxVectorDiff(result.scalaVector, Vector(4.0, 6.0)))
+        .asserting(_ shouldBe (0.0 +- 1e-10))
+    }
+
+    "compute finite-difference Jacobian close to analytical" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- NonLinearForwardModel.of[IO](
+                   evaluation         = nonlinearEval,
+                   differential       = 1e-7,
+                   domainDimensions   = Map("x" -> 2),
+                   rangeDimension     = 2,
+                   evalCacheDepth     = None,
+                   jacobianCacheDepth = None
+                 )
+        jac <- model.jacobianAt(IndexedVectorCollection(Map("x" -> Vector(2.0, 3.0))))
+      } yield {
+        val jacMatrix = jac.genericScalaRepresentation("x")
+        // Expected: [[4, 0], [3, 2]]
+        val expected = Vector(Vector(4.0, 0.0), Vector(3.0, 2.0))
+        maxMatrixDiff(jacMatrix, expected)
+      }).asserting(_ shouldBe (0.0 +- 1e-3))
+    }
+
+    "use user-provided analytical Jacobian when given" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        model <- NonLinearForwardModel.of[IO](
+                   evaluation         = nonlinearEval,
+                   jacobian           = analyticJacobian,
+                   domainDimensions   = Map("x" -> 2),
+                   rangeDimension     = 2,
+                   evalCacheDepth     = None,
+                   jacobianCacheDepth = None
+                 )
+        jac <- model.jacobianAt(IndexedVectorCollection(Map("x" -> Vector(2.0, 3.0))))
+      } yield jac.genericScalaRepresentation("x"))
+        .asserting(_ shouldBe Vector(Vector(4.0, 0.0), Vector(3.0, 2.0)))
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/components/likelihood/GaussianLinearLikelihoodSpec.scala
+++ b/src/test/scala/thylacine/model/components/likelihood/GaussianLinearLikelihoodSpec.scala
@@ -46,5 +46,17 @@ class GaussianLinearLikelihoodSpec extends AsyncFreeSpec with AsyncIOSpec with M
       } yield result.genericScalaRepresentation)
         .asserting(_ shouldBe Map("foo" -> Vector(-4e5, -88e4)))
     }
+
+    // J^T * Σ_obs^(-1) * (data - J*θ) at θ=(0,0)
+    // J=[[1,3],[2,4]], Σ_obs^(-1)=diag(40000,40000), data=(7,10)
+    // = [[1,2],[3,4]] * (280000, 400000) = (1080000, 2440000)
+    "generate the correct gradient at a second non-trivial point" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood <- fooLikelihoodF
+        result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(0d, 0d))))
+      } yield result.genericScalaRepresentation)
+        .asserting(_ shouldBe Map("foo" -> Vector(108e4, 244e4)))
+    }
   }
 }

--- a/src/test/scala/thylacine/model/components/likelihood/UniformLikelihoodSpec.scala
+++ b/src/test/scala/thylacine/model/components/likelihood/UniformLikelihoodSpec.scala
@@ -1,0 +1,76 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.likelihood
+
+import bengal.stm.STM
+import thylacine.model.components.forwardmodel.LinearForwardModel
+import thylacine.model.core.values.IndexedVectorCollection
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class UniformLikelihoodSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  // 1D identity forward model with uniform observation bounds [0, 5]
+  private def uniformLikelihoodF(implicit stm: STM[IO]): IO[UniformLikelihood[IO, LinearForwardModel[IO]]] =
+    for {
+      fm <- LinearForwardModel.of[IO](
+              label          = "x",
+              values         = Vector(Vector(1.0)),
+              evalCacheDepth = None
+            )
+    } yield UniformLikelihood[IO, LinearForwardModel[IO]](
+      forwardModel = fm,
+      upperBounds  = Vector(5.0),
+      lowerBounds  = Vector(0.0)
+    )
+
+  "UniformLikelihood" - {
+
+    "return finite logPdf when forward model output is inside bounds" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood <- uniformLikelihoodF
+        result     <- likelihood.logPdfAt(IndexedVectorCollection(Map("x" -> Vector(2.0))))
+      } yield result)
+        .asserting { r =>
+          r shouldBe (-Math.log(5.0) +- 1e-8)
+        }
+    }
+
+    "return negative infinity logPdf when forward model output is outside bounds" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood <- uniformLikelihoodF
+        result     <- likelihood.logPdfAt(IndexedVectorCollection(Map("x" -> Vector(6.0))))
+      } yield result)
+        .asserting(_ shouldBe Double.NegativeInfinity)
+    }
+
+    "return zero gradient inside bounds" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        likelihood <- uniformLikelihoodF
+        result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("x" -> Vector(2.0))))
+      } yield result.genericScalaRepresentation)
+        .asserting(_ shouldBe Map("x" -> Vector(0.0)))
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/components/posterior/ConjugateGradientCauchySpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/ConjugateGradientCauchySpec.scala
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.posterior
+
+import bengal.stm.STM
+import thylacine.TestUtils.maxIndexVectorDiff
+import thylacine.config.ConjugateGradientConfig
+import thylacine.model.components.likelihood.{ GaussianLinearLikelihood, Likelihood }
+import thylacine.model.components.prior.{ CauchyPrior, Prior }
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class ConjugateGradientCauchySpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  private val cgConfig = ConjugateGradientConfig(
+    convergenceThreshold      = 1e-15,
+    goldenSectionTolerance    = 1e-10,
+    lineProbeExpansionFactor  = 2.0,
+    minimumNumberOfIterations = 100
+  )
+
+  // CauchyPrior: center=0, CI=2 (variance=1)
+  // GaussianLinearLikelihood: identity, measurement=3, uncertainty=0.01 (variance=0.000025)
+  // The tight likelihood should dominate → optimizer converges near x≈3
+  "ConjugateGradientOptimisedPosterior with Cauchy prior" - {
+
+    "converge to the correct value after gradient fix" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        cauchyPrior = CauchyPrior[IO](
+                        label               = "x",
+                        values              = Vector(0.0),
+                        confidenceIntervals = Vector(2.0)
+                      )
+        likelihood <- GaussianLinearLikelihood.of[IO](
+                        coefficients   = Vector(Vector(1.0)),
+                        measurements   = Vector(3.0),
+                        uncertainties  = Vector(0.01),
+                        priorLabel     = "x",
+                        evalCacheDepth = None
+                      )
+        unnormalisedPosterior = UnnormalisedPosterior[IO](
+                                  priors      = Set[Prior[IO, ?]](cauchyPrior),
+                                  likelihoods = Set[Likelihood[IO, ?, ?]](likelihood)
+                                )
+        optimizer = ConjugateGradientOptimisedPosterior[IO](
+                      conjugateGradientConfig = cgConfig,
+                      posterior               = unnormalisedPosterior,
+                      iterationUpdateCallback = _ => IO.unit,
+                      isConvergedCallback     = _ => IO.unit
+                    )
+        result <- optimizer.findMaximumLogPdf(Map("x" -> Vector(0.0)))
+      } yield maxIndexVectorDiff(result._2, Map("x" -> Vector(3.0))))
+        .asserting(_ shouldBe (0.0 +- 0.1))
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/components/posterior/PosteriorGradientSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/PosteriorGradientSpec.scala
@@ -1,0 +1,109 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.posterior
+
+import bengal.stm.STM
+import thylacine.TestUtils.maxIndexVectorDiff
+import thylacine.model.components.likelihood.{ GaussianLinearLikelihood, Likelihood }
+import thylacine.model.components.prior.{ GaussianPrior, Prior }
+import thylacine.model.core.values.IndexedVectorCollection
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class PosteriorGradientSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  // Prior "x": mean=0, CI=2 → σ²=1
+  // Prior "y": mean=1, CI=4 → σ²=4
+  // Likelihood for x: identity, data=2, uncertainty=2 → σ²_obs=1
+  // Likelihood for y: identity, data=3, uncertainty=4 → σ²_obs=4
+  private val priorX = GaussianPrior.fromConfidenceIntervals[IO](
+    label               = "x",
+    values              = Vector(0.0),
+    confidenceIntervals = Vector(2.0)
+  )
+
+  private val priorY = GaussianPrior.fromConfidenceIntervals[IO](
+    label               = "y",
+    values              = Vector(1.0),
+    confidenceIntervals = Vector(4.0)
+  )
+
+  private def posteriorF(implicit stm: STM[IO]): IO[UnnormalisedPosterior[IO]] =
+    for {
+      likelihoodX <- GaussianLinearLikelihood.of[IO](
+                       coefficients   = Vector(Vector(1.0)),
+                       measurements   = Vector(2.0),
+                       uncertainties  = Vector(2.0),
+                       priorLabel     = "x",
+                       evalCacheDepth = None
+                     )
+      likelihoodY <- GaussianLinearLikelihood.of[IO](
+                       coefficients   = Vector(Vector(1.0)),
+                       measurements   = Vector(3.0),
+                       uncertainties  = Vector(4.0),
+                       priorLabel     = "y",
+                       evalCacheDepth = None
+                     )
+    } yield UnnormalisedPosterior[IO](
+      priors      = Set[Prior[IO, ?]](priorX, priorY),
+      likelihoods = Set[Likelihood[IO, ?, ?]](likelihoodX, likelihoodY)
+    )
+
+  "UnnormalisedPosterior gradient" - {
+
+    // At θ=(x=0, y=0):
+    // Prior x gradient: 1*(0-0) = 0
+    // Prior y gradient: (1/4)*(1-0) = 0.25
+    // Likelihood x: 1*1*(2-0) = 2
+    // Likelihood y: 1*(1/4)*(3-0) = 0.75
+    // Total: x → 0+2=2, y → 0.25+0.75=1.0
+    "equal sum of prior and likelihood gradients" in {
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        posterior <- posteriorF
+        grad     <- posterior.logPdfGradientAt(IndexedVectorCollection(Map("x" -> Vector(0.0), "y" -> Vector(0.0))))
+      } yield grad.genericScalaRepresentation)
+        .asserting { g =>
+          maxIndexVectorDiff(g, Map("x" -> Vector(2.0), "y" -> Vector(1.0))) shouldBe (0.0 +- 1e-8)
+        }
+    }
+
+    "match gradient via finite differences" in {
+      val testPoint = Map("x" -> Vector(0.5), "y" -> Vector(1.5))
+      val eps       = 1e-7
+      (for {
+        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
+        posterior <- posteriorF
+        grad     <- posterior.logPdfGradientAt(IndexedVectorCollection(testPoint))
+        logPdf0  <- posterior.logPdfAt(IndexedVectorCollection(testPoint))
+        logPdfNx <- posterior.logPdfAt(
+                      IndexedVectorCollection(Map("x" -> Vector(0.5 + eps), "y" -> Vector(1.5)))
+                    )
+        logPdfNy <- posterior.logPdfAt(
+                      IndexedVectorCollection(Map("x" -> Vector(0.5), "y" -> Vector(1.5 + eps)))
+                    )
+      } yield {
+        val fdGrad = Map("x" -> Vector((logPdfNx - logPdf0) / eps), "y" -> Vector((logPdfNy - logPdf0) / eps))
+        maxIndexVectorDiff(grad.genericScalaRepresentation, fdGrad)
+      }).asserting(_ shouldBe (0.0 +- 1e-5))
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/components/posterior/PosteriorGradientSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/PosteriorGradientSpec.scala
@@ -79,7 +79,7 @@ class PosteriorGradientSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
         posterior <- posteriorF
-        grad     <- posterior.logPdfGradientAt(IndexedVectorCollection(Map("x" -> Vector(0.0), "y" -> Vector(0.0))))
+        grad      <- posterior.logPdfGradientAt(IndexedVectorCollection(Map("x" -> Vector(0.0), "y" -> Vector(0.0))))
       } yield grad.genericScalaRepresentation)
         .asserting { g =>
           maxIndexVectorDiff(g, Map("x" -> Vector(2.0), "y" -> Vector(1.0))) shouldBe (0.0 +- 1e-8)
@@ -92,8 +92,8 @@ class PosteriorGradientSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers
       (for {
         case implicit0(stm: STM[IO]) <- STM.runtime[IO]
         posterior <- posteriorF
-        grad     <- posterior.logPdfGradientAt(IndexedVectorCollection(testPoint))
-        logPdf0  <- posterior.logPdfAt(IndexedVectorCollection(testPoint))
+        grad      <- posterior.logPdfGradientAt(IndexedVectorCollection(testPoint))
+        logPdf0   <- posterior.logPdfAt(IndexedVectorCollection(testPoint))
         logPdfNx <- posterior.logPdfAt(
                       IndexedVectorCollection(Map("x" -> Vector(0.5 + eps), "y" -> Vector(1.5)))
                     )

--- a/src/test/scala/thylacine/model/components/prior/CauchyPriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/prior/CauchyPriorSpec.scala
@@ -1,0 +1,60 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.prior
+
+import thylacine.model.core.values.VectorContainer
+import thylacine.model.distributions.CauchyDistribution
+
+import cats.effect.IO
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class CauchyPriorSpec extends AnyFlatSpec with should.Matchers {
+
+  private val tol = 1e-8
+
+  // CI=2 → variance=(2/2)^2=1
+  private val prior = CauchyPrior[IO](
+    label               = "x",
+    values              = Vector(0.0),
+    confidenceIntervals = Vector(2.0)
+  )
+
+  private val dist = CauchyDistribution(prior.priorData)
+
+  "CauchyPrior" should "compute correct gradient at a non-mean point" in {
+    // μ=0, σ²=1, x=1: Q=1, gradient = -(1+1)/(1+1) * 1 * 1 = -1.0
+    val grad = prior.rawLogPdfGradientAt(Vector(1.0))
+    grad(0) shouldBe (-1.0 +- tol)
+  }
+
+  it should "compute zero gradient at the mean" in {
+    val grad = prior.rawLogPdfGradientAt(Vector(0.0))
+    grad(0) shouldBe (0.0 +- tol)
+  }
+
+  it should "match gradient via finite differences" in {
+    val x          = Vector(1.5)
+    val eps        = 1e-7
+    val grad       = prior.rawLogPdfGradientAt(x)
+    val logPdfBase = dist.logPdfAt(VectorContainer(x))
+    val logPdfNudge = dist.logPdfAt(VectorContainer(Vector(x(0) + eps)))
+    val fdGrad     = (logPdfNudge - logPdfBase) / eps
+    grad(0) shouldBe (fdGrad +- 1e-5)
+  }
+}

--- a/src/test/scala/thylacine/model/components/prior/CauchyPriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/prior/CauchyPriorSpec.scala
@@ -49,12 +49,12 @@ class CauchyPriorSpec extends AnyFlatSpec with should.Matchers {
   }
 
   it should "match gradient via finite differences" in {
-    val x          = Vector(1.5)
-    val eps        = 1e-7
-    val grad       = prior.rawLogPdfGradientAt(x)
-    val logPdfBase = dist.logPdfAt(VectorContainer(x))
+    val x           = Vector(1.5)
+    val eps         = 1e-7
+    val grad        = prior.rawLogPdfGradientAt(x)
+    val logPdfBase  = dist.logPdfAt(VectorContainer(x))
     val logPdfNudge = dist.logPdfAt(VectorContainer(Vector(x(0) + eps)))
-    val fdGrad     = (logPdfNudge - logPdfBase) / eps
+    val fdGrad      = (logPdfNudge - logPdfBase) / eps
     grad(0) shouldBe (fdGrad +- 1e-5)
   }
 }

--- a/src/test/scala/thylacine/model/components/prior/UniformPriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/prior/UniformPriorSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.components.prior
+
+import thylacine.model.core.values.IndexedVectorCollection
+
+import cats.effect.IO
+import cats.effect.testing.scalatest.AsyncIOSpec
+import org.scalatest.freespec.AsyncFreeSpec
+import org.scalatest.matchers.should.Matchers
+
+class UniformPriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
+
+  private val prior = UniformPrior.fromBounds[IO](
+    label     = "x",
+    maxBounds = Vector(5.0),
+    minBounds = Vector(-5.0)
+  )
+
+  "UniformPrior" - {
+
+    "return zero gradient inside bounds" in {
+      IO(prior.rawLogPdfGradientAt(Vector(0.0)))
+        .asserting(_ shouldBe Vector(0.0))
+    }
+
+    "return correct logPdf inside bounds" in {
+      // Volume = 10, logPdf = -log(10)
+      prior
+        .logPdfAt(IndexedVectorCollection(Map("x" -> Vector(0.0))))
+        .asserting(_ shouldBe (-Math.log(10.0) +- 1e-8))
+    }
+
+    "return negative infinity logPdf outside bounds" in {
+      prior
+        .logPdfAt(IndexedVectorCollection(Map("x" -> Vector(6.0))))
+        .asserting(_ shouldBe Double.NegativeInfinity)
+    }
+  }
+}

--- a/src/test/scala/thylacine/model/core/computation/FiniteDifferenceJacobianSpec.scala
+++ b/src/test/scala/thylacine/model/core/computation/FiniteDifferenceJacobianSpec.scala
@@ -1,0 +1,55 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.model.core.computation
+
+import thylacine.TestUtils.*
+import thylacine.model.core.values.{ IndexedVectorCollection, VectorContainer }
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class FiniteDifferenceJacobianSpec extends AnyFlatSpec with should.Matchers {
+
+  // Linear: f(x1, x2) = [x1 + 2*x2, 3*x1 + 4*x2]
+  private val linearEval: IndexedVectorCollection => VectorContainer = { input =>
+    val x = input.index.head._2.scalaVector
+    VectorContainer(Vector(x(0) + 2 * x(1), 3 * x(0) + 4 * x(1)))
+  }
+
+  // Quadratic: f(x1, x2) = [x1^2, x1*x2]
+  private val quadraticEval: IndexedVectorCollection => VectorContainer = { input =>
+    val x = input.index.head._2.scalaVector
+    VectorContainer(Vector(x(0) * x(0), x(0) * x(1)))
+  }
+
+  "FiniteDifferenceJacobian" should "match exact Jacobian for a linear function" in {
+    val fdJac  = FiniteDifferenceJacobian(linearEval, 1e-7)
+    val result = fdJac.finiteDifferenceJacobianAt(IndexedVectorCollection(Map("p" -> Vector(1.0, 2.0))))
+    val jac    = result.genericScalaRepresentation("p")
+    // Exact: [[1, 2], [3, 4]]
+    maxMatrixDiff(jac, Vector(Vector(1.0, 2.0), Vector(3.0, 4.0))) shouldBe (0.0 +- 1e-6)
+  }
+
+  it should "approximate analytical Jacobian for a quadratic function" in {
+    val fdJac  = FiniteDifferenceJacobian(quadraticEval, 1e-7)
+    val result = fdJac.finiteDifferenceJacobianAt(IndexedVectorCollection(Map("p" -> Vector(2.0, 3.0))))
+    val jac    = result.genericScalaRepresentation("p")
+    // Analytical: [[2*x1, 0], [x2, x1]] = [[4, 0], [3, 2]]
+    maxMatrixDiff(jac, Vector(Vector(4.0, 0.0), Vector(3.0, 2.0))) shouldBe (0.0 +- 1e-3)
+  }
+}

--- a/src/test/scala/thylacine/util/ScalaVectorOpsSpec.scala
+++ b/src/test/scala/thylacine/util/ScalaVectorOpsSpec.scala
@@ -1,0 +1,50 @@
+/*
+ * Copyright 2023 Greg von Nessi
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package ai.entrolution
+package thylacine.util
+
+import thylacine.util.ScalaVectorOps.Implicits.*
+
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should
+
+class ScalaVectorOpsSpec extends AnyFlatSpec with should.Matchers {
+
+  "VectorOps" should "compute magnitudeSquared" in {
+    Vector(3.0, 4.0).magnitudeSquared shouldBe 25.0
+  }
+
+  it should "compute magnitude" in {
+    Vector(3.0, 4.0).magnitude shouldBe 5.0
+  }
+
+  it should "compute dotProductWith" in {
+    Vector(1.0, 2.0).dotProductWith(Vector(3.0, 4.0)) shouldBe 11.0
+  }
+
+  it should "compute scalarMultiplyWith" in {
+    Vector(1.0, 2.0).scalarMultiplyWith(3.0) shouldBe Vector(3.0, 6.0)
+  }
+
+  it should "compute add" in {
+    Vector(1.0, 2.0).add(Vector(3.0, 4.0)) shouldBe Vector(4.0, 6.0)
+  }
+
+  it should "compute subtract" in {
+    Vector(5.0, 6.0).subtract(Vector(1.0, 2.0)) shouldBe Vector(4.0, 4.0)
+  }
+}


### PR DESCRIPTION
## Summary

- Fix sign error in `CauchyDistribution.logPdfGradientAt` — the gradient multiplier was `+(1+d)/(1+Q)` instead of `-(1+d)/(1+Q)`, causing the gradient to point away from the mean
- Add 41 new tests covering gradients, Jacobians, and numerical computations across distributions, forward models, likelihoods, priors, and posteriors
- All analytical gradients cross-validated against finite-difference approximations
- New specs: LinearForwardModel, NonLinearForwardModel, FiniteDifferenceJacobian, CauchyLikelihood, UniformLikelihood, CauchyPrior, UniformPrior, PosteriorGradient, ConjugateGradientCauchy, ScalaVectorOps
- Extended specs: CauchyDistribution, GaussianDistribution, GaussianLinearLikelihood, GaussianLikelihood, GaussianAnalyticPosterior, HmcmcSampledPosterior
- Test count: 105 → 146

## Test plan

- [x] `sbt clean compile` — zero errors
- [x] `sbt test` — all 146 tests pass
- [x] `sbt headerCheckAll scalafmtCheckAll` — CI compliance verified
- [x] Cauchy gradient verified: points toward mean at x > μ, finite-difference match
- [x] CG optimizer converges correctly with Cauchy prior (regression test)