### PR TITLE
Add Scala 3 cross-build support

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,7 @@ jobs:
     strategy:
       matrix:
         os: [ubuntu-22.04]
-        scala: [2.13]
+        scala: [2.13, 3]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
@@ -124,6 +124,16 @@ jobs:
           name: target-${{ matrix.os }}-${{ matrix.java }}-2.13
 
       - name: Inflate target directories (2.13)
+        run: |
+          tar xf targets.tar
+          rm targets.tar
+
+      - name: Download target directories (3)
+        uses: actions/download-artifact@v6
+        with:
+          name: target-${{ matrix.os }}-${{ matrix.java }}-3
+
+      - name: Inflate target directories (3)
         run: |
           tar xf targets.tar
           rm targets.tar

--- a/build.sbt
+++ b/build.sbt
@@ -11,8 +11,8 @@ ThisBuild / developers ++= List(
 // CI configuration - Java 21 required for Smile 3.x
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
 
-scalaVersion                   := DependencyVersions.scala2p13Version
-ThisBuild / crossScalaVersions := Seq(DependencyVersions.scala2p13Version, DependencyVersions.scala3Version)
+scalaVersion                    := DependencyVersions.scala2p13Version
+ThisBuild / crossScalaVersions  := Seq(DependencyVersions.scala2p13Version, DependencyVersions.scala3Version)
 ThisBuild / tlVersionIntroduced := Map("3" -> "0.13")
 
 Global / idePackagePrefix := Some("ai.entrolution")

--- a/build.sbt
+++ b/build.sbt
@@ -20,13 +20,7 @@ Global / excludeLintKeys += idePackagePrefix
 
 lazy val commonSettings = Seq(
   scalaVersion := DependencyVersions.scala2p13Version,
-  scalacOptions ++= Seq(
-    "-deprecation",
-    "-feature",
-    "-unchecked",
-    "-encoding",
-    "UTF-8"
-  ) ++ (
+  scalacOptions ++= (
     if (scalaVersion.value.startsWith("2."))
       Seq("-Xlint:_", "-Ywarn-unused:-implicits", "-Ywarn-value-discard", "-Ywarn-dead-code")
     else

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.12"
+ThisBuild / tlBaseVersion := "0.13"
 
 ThisBuild / organization     := "ai.entrolution"
 ThisBuild / organizationName := "Greg von Nessi"
@@ -12,7 +12,8 @@ ThisBuild / developers ++= List(
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
 
 scalaVersion                   := DependencyVersions.scala2p13Version
-ThisBuild / crossScalaVersions := Seq(DependencyVersions.scala2p13Version)
+ThisBuild / crossScalaVersions := Seq(DependencyVersions.scala2p13Version, DependencyVersions.scala3Version)
+ThisBuild / tlVersionIntroduced := Map("3" -> "0.13")
 
 Global / idePackagePrefix := Some("ai.entrolution")
 Global / excludeLintKeys += idePackagePrefix
@@ -24,11 +25,12 @@ lazy val commonSettings = Seq(
     "-feature",
     "-unchecked",
     "-encoding",
-    "UTF-8",
-    "-Xlint:_",
-    "-Ywarn-unused:-implicits",
-    "-Ywarn-value-discard",
-    "-Ywarn-dead-code"
+    "UTF-8"
+  ) ++ (
+    if (scalaVersion.value.startsWith("2."))
+      Seq("-Xlint:_", "-Ywarn-unused:-implicits", "-Ywarn-value-discard", "-Ywarn-dead-code")
+    else
+      Seq("-Wunused:all")
   )
 )
 
@@ -38,6 +40,7 @@ lazy val thylacine = (project in file("."))
     name := "thylacine",
     libraryDependencies ++= Dependencies.thylacine,
     crossScalaVersions := Seq(
-      DependencyVersions.scala2p13Version
+      DependencyVersions.scala2p13Version,
+      DependencyVersions.scala3Version
     )
   )

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -2,6 +2,7 @@ import sbt.*
 
 object DependencyVersions {
   val scala2p13Version = "2.13.16"
+  val scala3Version    = "3.6.4"
 
   val bengalStmVersion           = "0.11.0"
   val bigMathVersion             = "2.3.2"

--- a/src/main/scala/thylacine/model/components/likelihood/Likelihood.scala
+++ b/src/main/scala/thylacine/model/components/likelihood/Likelihood.scala
@@ -65,5 +65,5 @@ trait Likelihood[F[_], +FM <: ForwardModel[F], +D <: Distribution]
           VectorContainer(LinearAlgebra.multiplyMV(jacobianTranspose, measGrad.rawVector))
         )
       }
-      .reduce(_ rawMergeWith _)
+      .reduce(_.rawMergeWith(_))
 }

--- a/src/main/scala/thylacine/model/components/posterior/GaussianAnalyticPosterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/GaussianAnalyticPosterior.scala
@@ -179,12 +179,12 @@ object GaussianAnalyticPosterior {
         .copy(
           priorMean = Some(
             this.priorMean
-              .map(_ rawConcatenateWith incomingPriorMean)
+              .map(_.rawConcatenateWith(incomingPriorMean))
               .getOrElse(incomingPriorMean)
           ),
           priorCovariance = Some(
             this.priorCovariance
-              .map(_ diagonalMergeWith incomingPriorCovariance)
+              .map(_.diagonalMergeWith(incomingPriorCovariance))
               .getOrElse(incomingPriorCovariance)
           )
         )
@@ -202,25 +202,25 @@ object GaussianAnalyticPosterior {
             MatrixContainer.zeros(likelihood.forwardModel.rangeDimension, id._2)
           )
         }
-        .reduce(_ columnMergeWith _)
+        .reduce(_.columnMergeWith(_))
 
       this.copy(
         data = Some(
           this.data
-            .map(_ rawConcatenateWith incomingData)
+            .map(_.rawConcatenateWith(incomingData))
             .getOrElse(incomingData)
         ),
         likelihoodCovariance = Some(
           this.likelihoodCovariance
             .map(
-              _ diagonalMergeWith incomingDataCovariance
+              _.diagonalMergeWith(incomingDataCovariance)
             )
             .getOrElse(incomingDataCovariance)
         ),
         likelihoodTransformations = Some(
           this.likelihoodTransformations
             .map(
-              _ rowMergeWith incomingTransformationMatrix
+              _.rowMergeWith(incomingTransformationMatrix)
             )
             .getOrElse(incomingTransformationMatrix)
         )

--- a/src/main/scala/thylacine/model/components/posterior/GaussianAnalyticPosterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/GaussianAnalyticPosterior.scala
@@ -29,6 +29,7 @@ import thylacine.util.LinearAlgebra
 
 import cats.effect.kernel.Async
 import cats.syntax.all.*
+import smile.math.matrix.Matrix
 import smile.stat.distribution.MultivariateGaussianDistribution
 
 import scala.Vector as ScalaVector
@@ -162,7 +163,7 @@ object GaussianAnalyticPosterior {
         // (newCovariance + newCovariance.t) * 0.5
         val symmetricCovariance = LinearAlgebra.symmetrize(newCovariance)
 
-        new MultivariateGaussianDistribution(newMean, LinearAlgebra.toArray2D(symmetricCovariance))
+        new MultivariateGaussianDistribution(newMean, Matrix.of(LinearAlgebra.toArray2D(symmetricCovariance)))
       }).getOrElse(
         throw new IllegalStateException(
           "Cannot create posterior Gaussian distribution: required prior or likelihood term is missing"

--- a/src/main/scala/thylacine/model/components/posterior/Posterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/Posterior.scala
@@ -54,15 +54,15 @@ private[thylacine] trait Posterior[F[_], P <: Prior[F, ?], L <: Likelihood[F, ?,
       priorSum <-
         priors.toList
           .traverse(_.logPdfGradientAt(input))
-          .map(_.reduce(_ rawSumWith _))
+          .map(_.reduce(_.rawSumWith(_)))
       likelihoodSum <-
         likelihoods.toList
           .traverse(_.logPdfGradientAt(input))
-          .map(_.reduce(_ rawSumWith _))
-    } yield priorSum rawSumWith likelihoodSum
+          .map(_.reduce(_.rawSumWith(_)))
+    } yield priorSum.rawSumWith(likelihoodSum)
 
   private[thylacine] def samplePriors: F[ModelParameterCollection] =
-    priors.toVector.traverse(_.sampleModelParameters(1).map(_.head)).map(_.reduce(_ rawMergeWith _))
+    priors.toVector.traverse(_.sampleModelParameters(1).map(_.head)).map(_.reduce(_.rawMergeWith(_)))
 
   override private[thylacine] def logPdfAt(
     input: ModelParameterCollection

--- a/src/main/scala/thylacine/model/core/AsyncImplicits.scala
+++ b/src/main/scala/thylacine/model/core/AsyncImplicits.scala
@@ -19,4 +19,4 @@ package thylacine.model.core
 
 import cats.effect.kernel.Async
 
-abstract class AsyncImplicits[F[_]](implicit protected val asyncF: Async[F])
+abstract class AsyncImplicits[F[_]](implicit val asyncF: Async[F])

--- a/src/main/scala/thylacine/model/core/GenericIdentifier.scala
+++ b/src/main/scala/thylacine/model/core/GenericIdentifier.scala
@@ -27,5 +27,5 @@ private[thylacine] object GenericIdentifier {
   private[thylacine] case class TermIdentifier(value: String) extends GenericIdentifier
 
   implicit private[thylacine] def orderByValue[T <: GenericIdentifier]: Ordering[T] =
-    Ordering.fromLessThan((i, j) => (i.value compareTo j.value) < 0)
+    Ordering.fromLessThan((i, j) => i.value.compareTo(j.value) < 0)
 }

--- a/src/main/scala/thylacine/model/core/StmImplicits.scala
+++ b/src/main/scala/thylacine/model/core/StmImplicits.scala
@@ -21,5 +21,4 @@ import bengal.stm.STM
 
 import cats.effect.kernel.Async
 
-abstract class StmImplicits[F[_]](implicit protected val stmF: STM[F], implicit override protected val asyncF: Async[F])
-    extends AsyncImplicits[F]
+abstract class StmImplicits[F[_]](implicit val stmF: STM[F], override val asyncF: Async[F]) extends AsyncImplicits[F]

--- a/src/main/scala/thylacine/model/core/values/IndexedVectorCollection.scala
+++ b/src/main/scala/thylacine/model/core/values/IndexedVectorCollection.scala
@@ -70,7 +70,7 @@ private[thylacine] case class IndexedVectorCollection(
       keySet.flatMap { k =>
         (getValidated.index.get(k), other.getValidated.index.get(k)) match {
           case (Some(v1), Some(v2)) =>
-            Some(k -> (v1 rawSumWith v2))
+            Some(k -> v1.rawSumWith(v2))
           case (Some(v1), _) =>
             Some(k -> v1)
           case (_, Some(v2)) =>
@@ -145,7 +145,7 @@ private[thylacine] object IndexedVectorCollection {
     labeledLists: Map[String, Vector[Double]]
   ): IndexedVectorCollection =
     if (labeledLists.nonEmpty)
-      labeledLists.map(i => apply(i._1, i._2)).reduce(_ rawMergeWith _)
+      labeledLists.map(i => apply(i._1, i._2)).reduce(_.rawMergeWith(_))
     else
       empty
 }

--- a/src/main/scala/thylacine/model/core/values/modelparameters/ModelParameterPdf.scala
+++ b/src/main/scala/thylacine/model/core/values/modelparameters/ModelParameterPdf.scala
@@ -61,7 +61,7 @@ private[thylacine] trait ModelParameterPdf[F[_]] extends GenericScalarValuedMapp
                               VectorContainer(finiteDifferenceResults.toVector)
                             )
                           }
-      result <- Async[F].delay(componentResults.reduce(_ rawMergeWith _))
+      result <- Async[F].delay(componentResults.reduce(_.rawMergeWith(_)))
     } yield result
 
   // Will work most of the time but will require
@@ -76,7 +76,7 @@ private[thylacine] trait ModelParameterPdf[F[_]] extends GenericScalarValuedMapp
       .map { gl =>
         IndexedVectorCollection(gl._1, VectorContainer(gl._2.rawVector.map(_ * pdf)))
       }
-      .reduce(_ rawMergeWith _)
+      .reduce(_.rawMergeWith(_))
 
   final def logPdfAt(input: Map[String, Vector[Double]]): F[Double] =
     logPdfAt(IndexedVectorCollection(input))

--- a/src/main/scala/thylacine/model/distributions/CauchyDistribution.scala
+++ b/src/main/scala/thylacine/model/distributions/CauchyDistribution.scala
@@ -21,6 +21,7 @@ import thylacine.model.core.values.{ MatrixContainer, VectorContainer }
 import thylacine.model.core.{ CanValidate, RecordedData }
 import thylacine.util.LinearAlgebra
 
+import smile.math.matrix.Matrix
 import smile.math.special.Gamma.gamma
 import smile.stat.distribution.{ ChiSquareDistribution, MultivariateGaussianDistribution }
 
@@ -77,7 +78,7 @@ private[thylacine] case class CauchyDistribution(
   private[thylacine] def getRawSample: VectorContainer = {
     val scaledCovariance = LinearAlgebra.divide(covariance.rawMatrix, chiSquared.rand())
     val scaledCovArray   = LinearAlgebra.toArray2D(scaledCovariance)
-    val mvn              = new MultivariateGaussianDistribution(mean.rawVector, scaledCovArray)
+    val mvn              = new MultivariateGaussianDistribution(mean.rawVector, Matrix.of(scaledCovArray))
     VectorContainer(mvn.rand())
   }
 

--- a/src/main/scala/thylacine/model/distributions/GaussianDistribution.scala
+++ b/src/main/scala/thylacine/model/distributions/GaussianDistribution.scala
@@ -21,6 +21,7 @@ import thylacine.model.core.values.{ MatrixContainer, VectorContainer }
 import thylacine.model.core.{ CanValidate, RecordedData }
 import thylacine.util.LinearAlgebra
 
+import smile.math.matrix.Matrix
 import smile.stat.distribution.MultivariateGaussianDistribution
 
 private[thylacine] case class GaussianDistribution(
@@ -45,7 +46,10 @@ private[thylacine] case class GaussianDistribution(
 
   // Low-level API
   private[thylacine] lazy val rawDistribution: MultivariateGaussianDistribution =
-    new MultivariateGaussianDistribution(mean.rawVector, covariance.genericScalaRepresentation.map(_.toArray).toArray)
+    new MultivariateGaussianDistribution(
+      mean.rawVector,
+      Matrix.of(covariance.genericScalaRepresentation.map(_.toArray).toArray)
+    )
 
   private lazy val rawInverseCovariance =
     LinearAlgebra.invert(covariance.rawMatrix)

--- a/src/test/scala/thylacine/model/components/likelihood/GaussianLinearLikelihoodSpec.scala
+++ b/src/test/scala/thylacine/model/components/likelihood/GaussianLinearLikelihoodSpec.scala
@@ -30,20 +30,26 @@ class GaussianLinearLikelihoodSpec extends AsyncFreeSpec with AsyncIOSpec with M
   "GaussianLinearLikelihood" - {
 
     "generate the a zero gradient at the likelihood maximum" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood <- fooLikelihoodF
-        result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(1d, 2d))))
-      } yield result.genericScalaRepresentation)
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            likelihood <- fooLikelihoodF
+            result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(1d, 2d))))
+          } yield result.genericScalaRepresentation
+        }
         .asserting(_ shouldBe Map("foo" -> Vector(0d, 0d)))
     }
 
     "generate the correct gradient of the logPdf for a given point" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood <- fooLikelihoodF
-        result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(3d, 2d))))
-      } yield result.genericScalaRepresentation)
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            likelihood <- fooLikelihoodF
+            result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(3d, 2d))))
+          } yield result.genericScalaRepresentation
+        }
         .asserting(_ shouldBe Map("foo" -> Vector(-4e5, -88e4)))
     }
 
@@ -51,11 +57,14 @@ class GaussianLinearLikelihoodSpec extends AsyncFreeSpec with AsyncIOSpec with M
     // J=[[1,3],[2,4]], Σ_obs^(-1)=diag(40000,40000), data=(7,10)
     // = [[1,2],[3,4]] * (280000, 400000) = (1080000, 2440000)
     "generate the correct gradient at a second non-trivial point" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood <- fooLikelihoodF
-        result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(0d, 0d))))
-      } yield result.genericScalaRepresentation)
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            likelihood <- fooLikelihoodF
+            result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("foo" -> Vector(0d, 0d))))
+          } yield result.genericScalaRepresentation
+        }
         .asserting(_ shouldBe Map("foo" -> Vector(108e4, 244e4)))
     }
   }

--- a/src/test/scala/thylacine/model/components/likelihood/UniformLikelihoodSpec.scala
+++ b/src/test/scala/thylacine/model/components/likelihood/UniformLikelihoodSpec.scala
@@ -45,31 +45,40 @@ class UniformLikelihoodSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers
   "UniformLikelihood" - {
 
     "return finite logPdf when forward model output is inside bounds" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood <- uniformLikelihoodF
-        result     <- likelihood.logPdfAt(IndexedVectorCollection(Map("x" -> Vector(2.0))))
-      } yield result)
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            likelihood <- uniformLikelihoodF
+            result     <- likelihood.logPdfAt(IndexedVectorCollection(Map("x" -> Vector(2.0))))
+          } yield result
+        }
         .asserting { r =>
           r shouldBe (-Math.log(5.0) +- 1e-8)
         }
     }
 
     "return negative infinity logPdf when forward model output is outside bounds" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood <- uniformLikelihoodF
-        result     <- likelihood.logPdfAt(IndexedVectorCollection(Map("x" -> Vector(6.0))))
-      } yield result)
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            likelihood <- uniformLikelihoodF
+            result     <- likelihood.logPdfAt(IndexedVectorCollection(Map("x" -> Vector(6.0))))
+          } yield result
+        }
         .asserting(_ shouldBe Double.NegativeInfinity)
     }
 
     "return zero gradient inside bounds" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        likelihood <- uniformLikelihoodF
-        result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("x" -> Vector(2.0))))
-      } yield result.genericScalaRepresentation)
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            likelihood <- uniformLikelihoodF
+            result     <- likelihood.logPdfGradientAt(IndexedVectorCollection(Map("x" -> Vector(2.0))))
+          } yield result.genericScalaRepresentation
+        }
         .asserting(_ shouldBe Map("x" -> Vector(0.0)))
     }
   }

--- a/src/test/scala/thylacine/model/components/posterior/ConjugateGradientOptimisedPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/ConjugateGradientOptimisedPosteriorSpec.scala
@@ -29,12 +29,15 @@ import org.scalatest.matchers.should.Matchers
 class ConjugateGradientOptimisedPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
   "ConjugateGradientOptimisedPosterior" - {
     "find the parameters that correspond to the posterior maximum" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        posterior <- conjugateGradientOptimisedPosteriorF
-        optimisationResult <-
-          posterior.findMaximumLogPdf(Map("fooniform" -> Vector(.5d, .5d), "barniform" -> Vector(3d)))
-      } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5))))
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            posterior <- conjugateGradientOptimisedPosteriorF
+            optimisationResult <-
+              posterior.findMaximumLogPdf(Map("fooniform" -> Vector(.5d, .5d), "barniform" -> Vector(3d)))
+          } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5)))
+        }
         .asserting(_ shouldBe (0.0 +- 1e-1))
     }
   }

--- a/src/test/scala/thylacine/model/components/posterior/CoordinateSlideOptimisedPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/CoordinateSlideOptimisedPosteriorSpec.scala
@@ -29,11 +29,14 @@ import org.scalatest.matchers.should.Matchers
 class CoordinateSlideOptimisedPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
   "CoordinateSlideOptimisedPosterior" - {
     "find the parameters that correspond to the posterior maximum" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        posterior          <- coordinateSlideOptimisedPosteriorF
-        optimisationResult <- posterior.findMaximumLogPdf(Map())
-      } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5))))
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            posterior          <- coordinateSlideOptimisedPosteriorF
+            optimisationResult <- posterior.findMaximumLogPdf(Map())
+          } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5)))
+        }
         .asserting(_ shouldBe (0.0 +- 1e-5))
     }
   }

--- a/src/test/scala/thylacine/model/components/posterior/HookeAndJeevesOptimisedPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/HookeAndJeevesOptimisedPosteriorSpec.scala
@@ -29,11 +29,14 @@ import org.scalatest.matchers.should.Matchers
 class HookeAndJeevesOptimisedPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
   "HookeAndJeevesOptimisedPosterior" - {
     "find the parameters that correspond to the posterior maximum" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        posterior          <- hookeAndJeevesOptimisedPosteriorF
-        optimisationResult <- posterior.findMaximumLogPdf(Map())
-      } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5))))
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            posterior          <- hookeAndJeevesOptimisedPosteriorF
+            optimisationResult <- posterior.findMaximumLogPdf(Map())
+          } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5)))
+        }
         .asserting(_ shouldBe (0.0 +- 1e-5))
     }
   }

--- a/src/test/scala/thylacine/model/components/posterior/MdsOptimisedPosteriorSpec.scala
+++ b/src/test/scala/thylacine/model/components/posterior/MdsOptimisedPosteriorSpec.scala
@@ -29,11 +29,14 @@ import org.scalatest.matchers.should.Matchers
 class MdsOptimisedPosteriorSpec extends AsyncFreeSpec with AsyncIOSpec with Matchers {
   "MdsOptimisedPosterior" - {
     "find the parameters that correspond to the posterior maximum" in {
-      (for {
-        case implicit0(stm: STM[IO]) <- STM.runtime[IO]
-        posterior          <- mdsOptimisedPosteriorF
-        optimisationResult <- posterior.findMaximumLogPdf(Map())
-      } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5))))
+      STM
+        .runtime[IO]
+        .flatMap { implicit stm =>
+          for {
+            posterior          <- mdsOptimisedPosteriorF
+            optimisationResult <- posterior.findMaximumLogPdf(Map())
+          } yield maxIndexVectorDiff(optimisationResult._2, Map("fooniform" -> Vector(1, 2), "barniform" -> Vector(5)))
+        }
         .asserting(_ shouldBe (0.0 +- 1e5))
     }
   }


### PR DESCRIPTION
## Summary
- Add Scala 3.6.4 to `crossScalaVersions` so thylacine publishes both `_2.13` and `_3` artifacts
- Make `scalacOptions` version-conditional (Scala 2 lint flags vs Scala 3 `-Wunused:all`)
- Add `tlVersionIntroduced := Map("3" -> "0.13")` to skip MiMa for the new `_3` artifact
- Bump `tlBaseVersion` from `0.12` to `0.13`
- Replace all 46 `implicit0` usages across 15 test files with `STM.runtime[IO].flatMap { implicit stm => ... }`
- Fix Scala 3 compilation issues: remove `protected` from implicit vals in `AsyncImplicits`/`StmImplicits`, use `Matrix.of()` instead of implicit Array-to-Matrix conversion, remove repeated `implicit` modifier

## Test plan
- [ ] `sbt +compile` passes on both Scala 2.13 and 3
- [ ] `sbt +test` — all 146 tests pass on both versions
- [ ] `sbt headerCheckAll scalafmtCheckAll` — formatting/header compliance
- [ ] `sbt githubWorkflowCheck` — CI workflow matches build config
- [ ] CI matrix now includes `scala: [2.13, 3]`