### PR TITLE
Centralize RNG through MathOps and convert remaining assert to require

### DIFF
--- a/src/main/scala/thylacine/model/distributions/UniformDistribution.scala
+++ b/src/main/scala/thylacine/model/distributions/UniformDistribution.scala
@@ -19,6 +19,7 @@ package thylacine.model.distributions
 
 import thylacine.model.core.CanValidate
 import thylacine.model.core.values.VectorContainer
+import thylacine.util.MathOps
 
 import scala.collection.immutable.Vector as ScalaVector
 import scala.collection.parallel.CollectionConverters.*
@@ -88,7 +89,7 @@ private[thylacine] case class UniformDistribution(
   private[thylacine] def getRawSample: VectorContainer =
     VectorContainer(
       samplingScalingAndShift.par.map { case (scale, offset) =>
-        Math.random() * scale + offset
+        MathOps.nextDouble * scale + offset
       }.toVector
     )
 

--- a/src/main/scala/thylacine/model/integration/slq/PointInCubeCollection.scala
+++ b/src/main/scala/thylacine/model/integration/slq/PointInCubeCollection.scala
@@ -96,7 +96,7 @@ private[thylacine] case class PointInCubeCollection(
   private[thylacine] def getSample(
     scaleParameter: Double
   ): VectorContainer = {
-    val randomIndex = BigDecimal(Math.random().toString)
+    val randomIndex = BigDecimal(MathOps.nextDouble.toString)
 
     sampleMapping
       .collect {

--- a/src/main/scala/thylacine/model/integration/slq/PointInInterval.scala
+++ b/src/main/scala/thylacine/model/integration/slq/PointInInterval.scala
@@ -18,6 +18,7 @@ package ai.entrolution
 package thylacine.model.integration.slq
 
 import thylacine.model.core.*
+import thylacine.util.MathOps
 
 private[thylacine] case class PointInInterval(
   point: Double,
@@ -62,7 +63,7 @@ private[thylacine] case class PointInInterval(
   // Sampling from a linearly scaled version of this interval (1 corresponding to
   // the original interval and 0 to the central point)
   private[thylacine] def getSample(scaleParameter: Double): Double =
-    (Math.random() - 0.5) * scaleParameter * (upperBound - lowerBound) + point
+    (MathOps.nextDouble - 0.5) * scaleParameter * (upperBound - lowerBound) + point
 }
 
 private[thylacine] object PointInInterval {

--- a/src/main/scala/thylacine/model/integration/slq/QuadratureAbscissa.scala
+++ b/src/main/scala/thylacine/model/integration/slq/QuadratureAbscissa.scala
@@ -17,6 +17,8 @@
 package ai.entrolution
 package thylacine.model.integration.slq
 
+import thylacine.util.MathOps
+
 import scala.annotation.tailrec
 
 // Mutable structure, as our quadratures may contain a large number
@@ -53,7 +55,7 @@ private[thylacine] object QuadratureAbscissa {
 
   @tailrec
   private def getNext(max: Double, existing: Set[Double]): Double = {
-    val candidate: Double = Math.random() * max
+    val candidate: Double = MathOps.nextDouble * max
     if (!existing.contains(candidate)) {
       candidate
     } else {

--- a/src/main/scala/thylacine/model/integration/slq/SamplingSimulation.scala
+++ b/src/main/scala/thylacine/model/integration/slq/SamplingSimulation.scala
@@ -22,8 +22,6 @@ import thylacine.util.MathOps
 
 import ch.obermuhlner.math.big.DefaultBigDecimalMath
 
-import scala.util.Random
-
 sealed private[thylacine] trait SamplingSimulation {
   private[thylacine] def getSample: ModelParameterCollection
   private[thylacine] def isConstructed: Boolean
@@ -79,14 +77,12 @@ private[thylacine] object SamplingSimulation {
         )
         .toMap
 
-    private val random = Random
-
     final override private[thylacine] val isConstructed: Boolean = true
 
     override private[thylacine] def getSample: ModelParameterCollection = {
-      lazy val continuousRandom = BigDecimal(Math.random().toString)
+      lazy val continuousRandom = BigDecimal(MathOps.nextDouble.toString)
 
-      indexedStaircase(random.nextInt(numberOfAbscissas) + 1)
+      indexedStaircase(MathOps.nextInt(numberOfAbscissas) + 1)
         .find {
           case ((staircaseLower, staircaseUpper), _)
               if staircaseLower <= continuousRandom && staircaseUpper > continuousRandom =>

--- a/src/main/scala/thylacine/model/integration/slq/SlqEngine.scala
+++ b/src/main/scala/thylacine/model/integration/slq/SlqEngine.scala
@@ -28,6 +28,7 @@ import thylacine.model.core.values.IndexedVectorCollection.ModelParameterCollect
 import thylacine.model.integration.ModelParameterIntegrator
 import thylacine.model.integration.slq.SamplingSimulation.*
 import thylacine.model.sampling.ModelParameterSampler
+import thylacine.util.MathOps
 
 import cats.effect.implicits.*
 import cats.effect.kernel.Async
@@ -106,7 +107,7 @@ private[thylacine] trait SlqEngine[F[_]] extends ModelParameterIntegrator[F] wit
 
   private def jitter(logPdf: Double): Txn[Double] = {
     val jitterResult =
-      Math.nextAfter(logPdf, logPdf + (if (Math.random() >= 0.5) 1 else -1))
+      Math.nextAfter(logPdf, logPdf + (if (MathOps.nextDouble >= 0.5) 1 else -1))
 
     samplePool
       .get(logPdf)

--- a/src/main/scala/thylacine/model/optimization/mds/ModelParameterSimplex.scala
+++ b/src/main/scala/thylacine/model/optimization/mds/ModelParameterSimplex.scala
@@ -51,7 +51,10 @@ private[thylacine] case class ModelParameterSimplex(
         }
         ._1
 
-    assert(!(isRegular ^ distancesAllEqual))
+    require(
+      !(isRegular ^ distancesAllEqual),
+      "Simplex regularity flag is inconsistent with computed vertex distances"
+    )
   }
 
   override private[thylacine] lazy val getValidated: ModelParameterSimplex =

--- a/src/main/scala/thylacine/model/sampling/hmcmc/HmcmcEngine.scala
+++ b/src/main/scala/thylacine/model/sampling/hmcmc/HmcmcEngine.scala
@@ -24,6 +24,7 @@ import thylacine.model.core.telemetry.HmcmcTelemetryUpdate
 import thylacine.model.core.values.IndexedVectorCollection.ModelParameterCollection
 import thylacine.model.core.values.{ IndexedVectorCollection, VectorContainer }
 import thylacine.model.sampling.ModelParameterSampler
+import thylacine.util.MathOps
 
 import cats.effect.implicits.*
 import cats.effect.kernel.Async
@@ -121,7 +122,7 @@ private[thylacine] trait HmcmcEngine[F[_]] extends ModelParameterSampler[F] {
                )
              ).start.void
            )
-      result <- Async[F].ifM(Async[F].delay(dH < 0 || Math.random() < Math.exp(-dH)))(
+      result <- Async[F].ifM(Async[F].delay(dH < 0 || MathOps.nextDouble < Math.exp(-dH)))(
                   for {
                     newGradNegLogPdf <- logPdfGradientAt(xNew).map(_.rawScalarMultiplyWith(-1))
                   } yield (xNew, eNew, newGradNegLogPdf, jumpAcceptances + 1, jumpAttempts + 1),

--- a/src/main/scala/thylacine/util/MathOps.scala
+++ b/src/main/scala/thylacine/util/MathOps.scala
@@ -110,4 +110,10 @@ private[thylacine] object MathOps {
   private[thylacine] def nextGaussian: Double =
     randomGenerator.nextGaussian()
 
+  private[thylacine] def nextDouble: Double =
+    randomGenerator.nextDouble()
+
+  private[thylacine] def nextInt(bound: Int): Int =
+    randomGenerator.nextInt(bound)
+
 }


### PR DESCRIPTION
## Summary
- Add `nextDouble` and `nextInt` methods to `MathOps`, centralizing all RNG through one utility (alongside the existing `nextGaussian`)
- Replace 8 `Math.random()` calls and 2 direct `scala.util.Random` calls across 9 files with `MathOps.nextDouble` / `MathOps.nextInt`
- Convert the remaining `assert` in `ModelParameterSimplex` to `require` with a descriptive message (missed in PR #24)

This is the final PR in the cleanup series (PRs #22–#26). Centralizing RNG makes it trivial to swap to a seeded `Random` for reproducible tests in future.

## Test plan
- [x] `sbt +clean +compile` — zero errors on both Scala 2.13 and 3
- [x] `sbt +test` — all 146 tests pass on both versions
- [x] `sbt 'scalafmtAll; Test/scalafmtAll; scalafmtSbt; headerCheckAll'` — CI compliance
- [x] `sbt githubWorkflowCheck` — CI workflow consistent