### PR TITLE
Remove Dependabot config for GitHub Actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,6 +1,0 @@
-version: 2
-updates:
-  - package-ecosystem: "github-actions"
-    directory: "/"
-    schedule:
-      interval: "weekly"


### PR DESCRIPTION
## Summary
- Remove `.github/dependabot.yml` — all workflow files are auto-generated by sbt-typelevel, so Dependabot cannot update action versions without breaking `githubWorkflowCheck`
- Closed PRs #29, #30, #31 which all failed CI for this reason

## Test plan
- [ ] CI passes (no functional change)