### PR TITLE
Update org references to Entrolution and add FUNDING.yml

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,2 @@
+github: gvonness-apolitical
+patreon: Entrolution

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -4,7 +4,7 @@ Thank you for your interest in contributing to Thylacine! This guide explains ho
 
 ## Reporting Bugs
 
-Open a [GitHub Issue](https://github.com/gvonness-apolitical/thylacine/issues/new?template=bug_report.md) with:
+Open a [GitHub Issue](https://github.com/Entrolution/thylacine/issues/new?template=bug_report.md) with:
 
 - A clear description of the problem
 - Steps to reproduce
@@ -13,7 +13,7 @@ Open a [GitHub Issue](https://github.com/gvonness-apolitical/thylacine/issues/ne
 
 ## Feature Requests
 
-Open a [GitHub Issue](https://github.com/gvonness-apolitical/thylacine/issues/new?template=feature_request.md) describing the motivation and proposed approach.
+Open a [GitHub Issue](https://github.com/Entrolution/thylacine/issues/new?template=feature_request.md) describing the motivation and proposed approach.
 
 ## Development Setup
 

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Thylacine
 
-[![CI](https://github.com/gvonness-apolitical/thylacine/actions/workflows/ci.yml/badge.svg)](https://github.com/gvonness-apolitical/thylacine/actions/workflows/ci.yml)
+[![CI](https://github.com/Entrolution/thylacine/actions/workflows/ci.yml/badge.svg)](https://github.com/Entrolution/thylacine/actions/workflows/ci.yml)
 [![Maven Central](https://img.shields.io/maven-central/v/ai.entrolution/thylacine_2.13)](https://central.sonatype.com/artifact/ai.entrolution/thylacine_2.13)
 ![Scala 2.13](https://img.shields.io/badge/Scala-2.13-red?logo=scala)
 ![Scala 3](https://img.shields.io/badge/Scala-3-red?logo=scala)
@@ -116,7 +116,7 @@ object BayesianUpdateExample extends IOApp.Simple {
 
 ## Framework Documentation
 
-API documentation is generated during CI for each Scala version. For questions and discussion, see [GitHub Discussions](https://github.com/gvonness-apolitical/thylacine/discussions).
+API documentation is generated during CI for each Scala version. For questions and discussion, see [GitHub Discussions](https://github.com/Entrolution/thylacine/discussions).
 
 ---
 ---

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -2,7 +2,7 @@
 
 ## Reporting a Vulnerability
 
-If you discover a security vulnerability in Thylacine, please report it responsibly via [GitHub Security Advisories](https://github.com/gvonness-apolitical/thylacine/security/advisories/new).
+If you discover a security vulnerability in Thylacine, please report it responsibly via [GitHub Security Advisories](https://github.com/Entrolution/thylacine/security/advisories/new).
 
 **Do not** open a public issue for security vulnerabilities.
 


### PR DESCRIPTION
## Summary
- Update all doc URLs from `gvonness-apolitical/thylacine` to `Entrolution/thylacine` (README, CONTRIBUTING, SECURITY)
- Add `.github/FUNDING.yml` with GitHub Sponsors (`gvonness-apolitical`) and Patreon (`Entrolution`)

## Test plan
- [ ] CI passes
- [ ] Sponsor button appears on repo page
- [ ] Doc links resolve to correct org