### PR TITLE
Add robustness guards, numerical stability, and version bump to 0.15

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,27 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [0.15.0] - 2026-02-26
+
+### Fixed
+
+- Infinite recursion in `exploreLine` on flat landscapes where probe differential overflows to infinity
+- Infinite recursion in `probeLine` on monotonically increasing or constant functions
+- Division by near-zero in conjugate gradient beta computation producing infinite search directions
+- Redundant forward model evaluations in `centralDifferenceJacobianAt` (hoisted `evalAt(input)` out of loop)
+
+### Added
+
+- Depth limits (max 50) to `exploreLine` and `probeLine` with `isInfinite`/`isNaN` guards
+- Max iteration guard (default 10,000) to MDS and Hooke-Jeeves optimizers to bound worst-case runtime
+- Validation that `goldenSectionTolerance > 0` in `ConjugateGradientConfig` and `CoordinateSlideConfig`
+- Cholesky-based `choleskySolve` and `choleskyInvert` to `LinearAlgebra` for symmetric positive definite matrices
+- `shuffle` and `setSeed` methods to `MathOps` for reproducible RNG
+
+### Changed
+
+- `GaussianAnalyticPosterior` now uses Cholesky factorization instead of generic matrix inversion for improved numerical stability
+- Centralized remaining direct `scala.util.Random` usages in `GoldenSectionSearch`, `HookeAndJeevesEngine`, and `CoordinateSlideEngine` through `MathOps`

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -21,4 +21,7 @@ If you discover a security vulnerability in Thylacine, please report it responsi
 
 ## Supported Versions
 
-Security fixes are applied to the latest release only.
+| Version | Supported |
+|---------|-----------|
+| 0.15.x  | Yes       |
+| < 0.15  | No        |

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.14"
+ThisBuild / tlBaseVersion := "0.15"
 
 ThisBuild / organization     := "ai.entrolution"
 ThisBuild / organizationName := "Greg von Nessi"

--- a/src/main/scala/thylacine/config/ConjugateGradientConfig.scala
+++ b/src/main/scala/thylacine/config/ConjugateGradientConfig.scala
@@ -22,4 +22,6 @@ case class ConjugateGradientConfig(
   goldenSectionTolerance: Double,
   lineProbeExpansionFactor: Double,
   minimumNumberOfIterations: Int
-)
+) {
+  require(goldenSectionTolerance > 0, s"goldenSectionTolerance must be > 0, got $goldenSectionTolerance")
+}

--- a/src/main/scala/thylacine/config/CoordinateSlideConfig.scala
+++ b/src/main/scala/thylacine/config/CoordinateSlideConfig.scala
@@ -22,4 +22,6 @@ case class CoordinateSlideConfig(
   goldenSectionTolerance: Double,
   lineProbeExpansionFactor: Double,
   numberOfPriorSamplesToSetScale: Option[Int]
-)
+) {
+  require(goldenSectionTolerance > 0, s"goldenSectionTolerance must be > 0, got $goldenSectionTolerance")
+}

--- a/src/main/scala/thylacine/model/core/computation/FiniteDifferenceJacobian.scala
+++ b/src/main/scala/thylacine/model/core/computation/FiniteDifferenceJacobian.scala
@@ -63,6 +63,8 @@ private[thylacine] case class FiniteDifferenceJacobian(
   private def centralDifferenceJacobianAt(
     input: IndexedVectorCollection
   ): IndexedMatrixCollection = {
+    val baseResult = evalAt(input)
+    val rangeDim   = baseResult.dimension
     val newMatrixCollectionMapping =
       input
         .rawNudgeComponentsCentral(differential)
@@ -79,7 +81,6 @@ private[thylacine] case class FiniteDifferenceJacobian(
                 .map(k => (k._1, index) -> k._2)
             }
 
-          val rangeDim = evalAt(input).dimension
           identifier -> MatrixContainer(gradientComponents.reduce(_ ++ _), rangeDim, nudgePairs.size)
         }
         .toMap

--- a/src/main/scala/thylacine/model/optimization/hookeandjeeves/CoordinateSlideEngine.scala
+++ b/src/main/scala/thylacine/model/optimization/hookeandjeeves/CoordinateSlideEngine.scala
@@ -21,11 +21,11 @@ import thylacine.model.components.posterior.Posterior
 import thylacine.model.components.prior.Prior
 import thylacine.model.core.AsyncImplicits
 import thylacine.model.optimization.line.GoldenSectionSearch
+import thylacine.util.MathOps
 
 import cats.effect.kernel.Async
 import cats.syntax.all.*
 
-import scala.util.Random
 import scala.Vector as ScalaVector
 
 // Modification of standard Hooke and Jeeves to leverage
@@ -43,7 +43,7 @@ private[thylacine] trait CoordinateSlideEngine[F[_]] extends HookeAndJeevesEngin
     startingPoint: ScalaVector[Double],
     startingLogPdf: Double
   ): F[(Double, ScalaVector[Double])] =
-    Random
+    MathOps
       .shuffle(startingPoint.indices.toList)
       .foldLeft(Async[F].pure((startingLogPdf, startingPoint))) { case (previousF, testIndex) =>
         previousF.flatMap { case previous @ (_, currentArgMax) =>

--- a/src/main/scala/thylacine/model/optimization/line/GoldenSectionSearch.scala
+++ b/src/main/scala/thylacine/model/optimization/line/GoldenSectionSearch.scala
@@ -54,7 +54,7 @@ private[thylacine] trait GoldenSectionSearch[F[_]] extends LineProbe[F] with Lin
     direction: Vector[Double],
     probeDifferential: Double,
     directionNormalised: Boolean = false,
-    depth: Int = 0
+    depth: Int                   = 0
   ): F[(Double, Vector[Double])] = {
     if (depth >= 50 || probeDifferential.isInfinite || probeDifferential.isNaN) {
       Async[F].pure(startPointEvaluation)
@@ -80,7 +80,7 @@ private[thylacine] trait GoldenSectionSearch[F[_]] extends LineProbe[F] with Lin
             normalisedDirection,
             probeDifferential * lineProbeExpansionFactor,
             directionNormalised = true,
-            depth = depth + 1
+            depth               = depth + 1
           )
         case (forwardPointResult, reversePointResult) =>
           searchColinearTriple(

--- a/src/main/scala/thylacine/model/optimization/line/LineProbe.scala
+++ b/src/main/scala/thylacine/model/optimization/line/LineProbe.scala
@@ -32,7 +32,8 @@ private[thylacine] trait LineProbe[F[_]] {
   protected def probeLine(
     pt1: LineEvaluationResult,
     pt2: LineEvaluationResult,
-    ordered: Boolean = false
+    ordered: Boolean = false,
+    depth: Int = 0
   ): F[LineEvaluationTriple] = {
     val (lowerPoint, upperPoint) =
       if (ordered || pt1.result < pt2.result) {
@@ -41,33 +42,43 @@ private[thylacine] trait LineProbe[F[_]] {
         (pt2, pt1)
       }
 
-    val probePointVector: Vector[Double] =
-      upperPoint.vectorArgument.zip(lowerPoint.vectorArgument).map {
-        case (upperPointCoordinate, lowerPointCoordinate) =>
-          lineProbeExpansionFactor * (upperPointCoordinate - lowerPointCoordinate) + upperPointCoordinate
+    if (depth >= 50) {
+      Async[F].pure {
+        LineEvaluationTriple(
+          firstEndPoint  = lowerPoint,
+          middlePoint    = upperPoint,
+          secondEndPoint = upperPoint
+        )
       }
+    } else {
+      val probePointVector: Vector[Double] =
+        upperPoint.vectorArgument.zip(lowerPoint.vectorArgument).map {
+          case (upperPointCoordinate, lowerPointCoordinate) =>
+            lineProbeExpansionFactor * (upperPointCoordinate - lowerPointCoordinate) + upperPointCoordinate
+        }
 
-    val probePointModelParameters: ModelParameterCollection =
-      vectorValuesToModelParameterCollection(probePointVector)
+      val probePointModelParameters: ModelParameterCollection =
+        vectorValuesToModelParameterCollection(probePointVector)
 
-    val probeEvaluationF: F[Double] = logPdfAt(probePointModelParameters)
+      val probeEvaluationF: F[Double] = logPdfAt(probePointModelParameters)
 
-    probeEvaluationF.flatMap { probeEvaluation =>
-      val evaluationResult = LineEvaluationResult(
-        result                 = probeEvaluation,
-        vectorArgument         = probePointVector,
-        modelParameterArgument = probePointModelParameters
-      )
+      probeEvaluationF.flatMap { probeEvaluation =>
+        val evaluationResult = LineEvaluationResult(
+          result                 = probeEvaluation,
+          vectorArgument         = probePointVector,
+          modelParameterArgument = probePointModelParameters
+        )
 
-      if (probeEvaluation >= upperPoint.result) {
-        probeLine(upperPoint, evaluationResult, ordered = true)
-      } else {
-        Async[F].delay {
-          LineEvaluationTriple(
-            firstEndPoint  = lowerPoint,
-            middlePoint    = upperPoint,
-            secondEndPoint = evaluationResult
-          )
+        if (probeEvaluation >= upperPoint.result) {
+          probeLine(upperPoint, evaluationResult, ordered = true, depth = depth + 1)
+        } else {
+          Async[F].delay {
+            LineEvaluationTriple(
+              firstEndPoint  = lowerPoint,
+              middlePoint    = upperPoint,
+              secondEndPoint = evaluationResult
+            )
+          }
         }
       }
     }

--- a/src/main/scala/thylacine/model/optimization/line/LineProbe.scala
+++ b/src/main/scala/thylacine/model/optimization/line/LineProbe.scala
@@ -33,7 +33,7 @@ private[thylacine] trait LineProbe[F[_]] {
     pt1: LineEvaluationResult,
     pt2: LineEvaluationResult,
     ordered: Boolean = false,
-    depth: Int = 0
+    depth: Int       = 0
   ): F[LineEvaluationTriple] = {
     val (lowerPoint, upperPoint) =
       if (ordered || pt1.result < pt2.result) {

--- a/src/main/scala/thylacine/util/MathOps.scala
+++ b/src/main/scala/thylacine/util/MathOps.scala
@@ -121,4 +121,10 @@ private[thylacine] object MathOps {
   private[thylacine] def nextInt(bound: Int): Int =
     randomGenerator.nextInt(bound)
 
+  private[thylacine] def shuffle[A](xs: List[A]): List[A] =
+    randomGenerator.shuffle(xs)
+
+  private[thylacine] def setSeed(seed: Long): Unit =
+    randomGenerator.setSeed(seed)
+
 }

--- a/src/test/scala/thylacine/util/MathOpsSpec.scala
+++ b/src/test/scala/thylacine/util/MathOpsSpec.scala
@@ -76,4 +76,28 @@ class MathOpsSpec extends AnyFreeSpec with Matchers {
       result(1)._1 shouldBe (result(1)._2 +- tol)
     }
   }
+
+  "setSeed" - {
+    "produce identical sequences for the same seed" in {
+      MathOps.setSeed(42L)
+      val firstRun = (1 to 10).map(_ => MathOps.nextDouble).toVector
+
+      MathOps.setSeed(42L)
+      val secondRun = (1 to 10).map(_ => MathOps.nextDouble).toVector
+
+      firstRun shouldBe secondRun
+    }
+
+    "produce identical shuffle results for the same seed" in {
+      val items = List(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)
+
+      MathOps.setSeed(123L)
+      val firstShuffle = MathOps.shuffle(items)
+
+      MathOps.setSeed(123L)
+      val secondShuffle = MathOps.shuffle(items)
+
+      firstShuffle shouldBe secondShuffle
+    }
+  }
 }


### PR DESCRIPTION
## Summary

- Add depth limits and overflow guards to line search recursion (`exploreLine`, `probeLine`) to prevent infinite recursion on flat/monotonic landscapes
- Guard conjugate gradient beta denominator against zero, restarting as steepest descent
- Add max iteration guards (default 10,000) to MDS and Hooke-Jeeves optimizers
- Validate `goldenSectionTolerance > 0` in config to prevent non-termination
- Hoist redundant `evalAt(input)` out of central difference Jacobian loop
- Replace generic matrix inversion with Cholesky factorization in `GaussianAnalyticPosterior` for improved numerical stability on SPD matrices
- Centralize remaining direct `scala.util.Random` usages through `MathOps` and add `setSeed`/`shuffle` API
- Bump version to 0.15, add CHANGELOG.md, update SECURITY.md

## Test plan

- [x] `sbt +test` passes (155/155 tests, Scala 2.13 + 3)
- [x] All existing optimization tests (CG, MDS, H&J, Coordinate Slide) pass
- [x] `GaussianAnalyticPosteriorSpec` passes with Cholesky-based computation
- [x] New `MathOpsSpec` seed reproducibility tests pass
- [x] Cross-compilation under Scala 3.6.4 succeeds