### PR TITLE
Update bengal-stm to 0.12.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.15.3] - 2026-02-27
+
+### Changed
+
+- Updated `bengal-stm` dependency from 0.11.0 to 0.12.0
+
 ## [0.15.2] - 2026-02-26
 
 ### Added

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object DependencyVersions {
   val scala2p13Version = "2.13.16"
   val scala3Version    = "3.6.4"
 
-  val bengalStmVersion           = "0.11.0"
+  val bengalStmVersion           = "0.12.0"
   val bigMathVersion             = "2.3.2"
   val catsEffectVersion          = "3.6.3"
   val catsEffectTestingVersion   = "1.7.0"


### PR DESCRIPTION
## Summary

- Update `bengal-stm` dependency from 0.11.0 to 0.12.0
- Add changelog entry for v0.15.3

## Test plan

- [x] `sbt +test` passes on both Scala 2.13 and 3 (220 tests each)
- [ ] CI passes