### PR TITLE
Downgrade Blacksmith runners to 2vcpu

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,7 +27,7 @@ jobs:
     name: Test
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2204]
+        os: [blacksmith-2vcpu-ubuntu-2204]
         scala: [2.13, 3]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
@@ -58,18 +58,18 @@ jobs:
         run: sbt githubWorkflowCheck
 
       - name: Check headers and formatting
-        if: matrix.java == 'temurin@21' && matrix.os == 'blacksmith-4vcpu-ubuntu-2204'
+        if: matrix.java == 'temurin@21' && matrix.os == 'blacksmith-2vcpu-ubuntu-2204'
         run: sbt '++ ${{ matrix.scala }}' headerCheckAll scalafmtCheckAll 'project /' scalafmtSbtCheck
 
       - name: Test
         run: sbt '++ ${{ matrix.scala }}' test
 
       - name: Check binary compatibility
-        if: matrix.java == 'temurin@21' && matrix.os == 'blacksmith-4vcpu-ubuntu-2204'
+        if: matrix.java == 'temurin@21' && matrix.os == 'blacksmith-2vcpu-ubuntu-2204'
         run: sbt '++ ${{ matrix.scala }}' mimaReportBinaryIssues
 
       - name: Generate API documentation
-        if: matrix.java == 'temurin@21' && matrix.os == 'blacksmith-4vcpu-ubuntu-2204'
+        if: matrix.java == 'temurin@21' && matrix.os == 'blacksmith-2vcpu-ubuntu-2204'
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
@@ -93,7 +93,7 @@ jobs:
     if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
     strategy:
       matrix:
-        os: [blacksmith-4vcpu-ubuntu-2204]
+        os: [blacksmith-2vcpu-ubuntu-2204]
         java: [temurin@21]
     runs-on: ${{ matrix.os }}
     steps:

--- a/build.sbt
+++ b/build.sbt
@@ -10,7 +10,7 @@ ThisBuild / developers ++= List(
 
 // CI configuration - Java 21 required for Smile 3.x
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
-ThisBuild / githubWorkflowOSes         := Seq("blacksmith-4vcpu-ubuntu-2204")
+ThisBuild / githubWorkflowOSes         := Seq("blacksmith-2vcpu-ubuntu-2204")
 
 scalaVersion                    := DependencyVersions.scala2p13Version
 ThisBuild / crossScalaVersions  := Seq(DependencyVersions.scala2p13Version, DependencyVersions.scala3Version)


### PR DESCRIPTION
Reduces runner size to stay within the free tier (3,000 min/month).