### PR TITLE
Release v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
+## [0.16.0] - 2026-03-10
+
+### Added
+
+- Parameter validation (`require`) to all 7 config case classes: `HmcmcConfig`, `LeapfrogMcmcConfig`, `SlqConfig`, `MdsConfig`, `HookeAndJeevesConfig`, `ConjugateGradientConfig`, `CoordinateSlideConfig`. Invalid parameters (negative step sizes, zero convergence thresholds, out-of-range probabilities, etc.) now fail at construction with descriptive error messages instead of causing confusing downstream errors.
+- Forward model validation in `GaussianLikelihood`, `UniformLikelihood`, and `GaussianLinearLikelihood` — `getValidated` now propagates validation to the forward model, consistent with `CauchyLikelihood`.
+
+### Changed
+
+- Updated `bengal-stm` dependency from 0.12.0 to 0.13.0
+- Replaced `.reduce` with `.reduceOption` across 8 call sites in 6 files (`Posterior`, `ModelParameterContext`, `ModelParameterPdf`, `FiniteDifferenceJacobian`, `GaussianAnalyticPosterior`, `Likelihood`) for defensive robustness against empty collections.
+
 ## [0.15.3] - 2026-02-27
 
 ### Changed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -23,5 +23,5 @@ If you discover a security vulnerability in Thylacine, please report it responsi
 
 | Version | Supported |
 |---------|-----------|
-| 0.15.x  | Yes       |
-| < 0.15  | No        |
+| 0.16.x  | Yes       |
+| < 0.16  | No        |

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / tlBaseVersion := "0.15"
+ThisBuild / tlBaseVersion := "0.16"
 
 ThisBuild / organization     := "ai.entrolution"
 ThisBuild / organizationName := "Greg von Nessi"
@@ -13,7 +13,7 @@ ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
 
 scalaVersion                    := DependencyVersions.scala2p13Version
 ThisBuild / crossScalaVersions  := Seq(DependencyVersions.scala2p13Version, DependencyVersions.scala3Version)
-ThisBuild / tlVersionIntroduced := Map("2.13" -> "0.15", "3" -> "0.15")
+ThisBuild / tlVersionIntroduced := Map("2.13" -> "0.16", "3" -> "0.16")
 
 Global / idePackagePrefix := Some("ai.entrolution")
 Global / excludeLintKeys += idePackagePrefix

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -4,7 +4,7 @@ object DependencyVersions {
   val scala2p13Version = "2.13.16"
   val scala3Version    = "3.6.4"
 
-  val bengalStmVersion           = "0.12.0"
+  val bengalStmVersion           = "0.13.0"
   val bigMathVersion             = "2.3.2"
   val catsEffectVersion          = "3.6.3"
   val catsEffectTestingVersion   = "1.7.0"

--- a/src/main/scala/thylacine/config/ConjugateGradientConfig.scala
+++ b/src/main/scala/thylacine/config/ConjugateGradientConfig.scala
@@ -23,5 +23,8 @@ case class ConjugateGradientConfig(
   lineProbeExpansionFactor: Double,
   minimumNumberOfIterations: Int
 ) {
+  require(convergenceThreshold > 0, s"convergenceThreshold must be > 0, got $convergenceThreshold")
   require(goldenSectionTolerance > 0, s"goldenSectionTolerance must be > 0, got $goldenSectionTolerance")
+  require(lineProbeExpansionFactor > 0, s"lineProbeExpansionFactor must be > 0, got $lineProbeExpansionFactor")
+  require(minimumNumberOfIterations > 0, s"minimumNumberOfIterations must be > 0, got $minimumNumberOfIterations")
 }

--- a/src/main/scala/thylacine/config/CoordinateSlideConfig.scala
+++ b/src/main/scala/thylacine/config/CoordinateSlideConfig.scala
@@ -23,5 +23,10 @@ case class CoordinateSlideConfig(
   lineProbeExpansionFactor: Double,
   numberOfPriorSamplesToSetScale: Option[Int]
 ) {
+  require(convergenceThreshold > 0, s"convergenceThreshold must be > 0, got $convergenceThreshold")
   require(goldenSectionTolerance > 0, s"goldenSectionTolerance must be > 0, got $goldenSectionTolerance")
+  require(lineProbeExpansionFactor > 0, s"lineProbeExpansionFactor must be > 0, got $lineProbeExpansionFactor")
+  numberOfPriorSamplesToSetScale.foreach(n =>
+    require(n > 0, s"numberOfPriorSamplesToSetScale must be > 0, got $n")
+  )
 }

--- a/src/main/scala/thylacine/config/CoordinateSlideConfig.scala
+++ b/src/main/scala/thylacine/config/CoordinateSlideConfig.scala
@@ -26,7 +26,5 @@ case class CoordinateSlideConfig(
   require(convergenceThreshold > 0, s"convergenceThreshold must be > 0, got $convergenceThreshold")
   require(goldenSectionTolerance > 0, s"goldenSectionTolerance must be > 0, got $goldenSectionTolerance")
   require(lineProbeExpansionFactor > 0, s"lineProbeExpansionFactor must be > 0, got $lineProbeExpansionFactor")
-  numberOfPriorSamplesToSetScale.foreach(n =>
-    require(n > 0, s"numberOfPriorSamplesToSetScale must be > 0, got $n")
-  )
+  numberOfPriorSamplesToSetScale.foreach(n => require(n > 0, s"numberOfPriorSamplesToSetScale must be > 0, got $n"))
 }

--- a/src/main/scala/thylacine/config/HmcmcConfig.scala
+++ b/src/main/scala/thylacine/config/HmcmcConfig.scala
@@ -25,4 +25,13 @@ case class HmcmcConfig(
   massMatrixDiagonal: Option[Vector[Double]] = None,
   adaptStepSize: Boolean                     = false,
   targetAcceptanceRate: Double               = 0.65
-)
+) {
+  require(stepsBetweenSamples > 0, s"stepsBetweenSamples must be > 0, got $stepsBetweenSamples")
+  require(stepsInDynamicsSimulation > 0, s"stepsInDynamicsSimulation must be > 0, got $stepsInDynamicsSimulation")
+  require(warmupStepCount >= 0, s"warmupStepCount must be >= 0, got $warmupStepCount")
+  require(dynamicsSimulationStepSize > 0, s"dynamicsSimulationStepSize must be > 0, got $dynamicsSimulationStepSize")
+  require(
+    targetAcceptanceRate > 0 && targetAcceptanceRate < 1,
+    s"targetAcceptanceRate must be in (0, 1), got $targetAcceptanceRate"
+  )
+}

--- a/src/main/scala/thylacine/config/HookeAndJeevesConfig.scala
+++ b/src/main/scala/thylacine/config/HookeAndJeevesConfig.scala
@@ -22,7 +22,5 @@ case class HookeAndJeevesConfig(
   numberOfPriorSamplesToSetScale: Option[Int]
 ) {
   require(convergenceThreshold > 0, s"convergenceThreshold must be > 0, got $convergenceThreshold")
-  numberOfPriorSamplesToSetScale.foreach(n =>
-    require(n > 0, s"numberOfPriorSamplesToSetScale must be > 0, got $n")
-  )
+  numberOfPriorSamplesToSetScale.foreach(n => require(n > 0, s"numberOfPriorSamplesToSetScale must be > 0, got $n"))
 }

--- a/src/main/scala/thylacine/config/HookeAndJeevesConfig.scala
+++ b/src/main/scala/thylacine/config/HookeAndJeevesConfig.scala
@@ -20,4 +20,9 @@ package thylacine.config
 case class HookeAndJeevesConfig(
   convergenceThreshold: Double,
   numberOfPriorSamplesToSetScale: Option[Int]
-)
+) {
+  require(convergenceThreshold > 0, s"convergenceThreshold must be > 0, got $convergenceThreshold")
+  numberOfPriorSamplesToSetScale.foreach(n =>
+    require(n > 0, s"numberOfPriorSamplesToSetScale must be > 0, got $n")
+  )
+}

--- a/src/main/scala/thylacine/config/LeapfrogMcmcConfig.scala
+++ b/src/main/scala/thylacine/config/LeapfrogMcmcConfig.scala
@@ -21,4 +21,8 @@ case class LeapfrogMcmcConfig(
   stepsBetweenSamples: Int,
   warmupStepCount: Int,
   samplePoolSize: Int
-)
+) {
+  require(stepsBetweenSamples > 0, s"stepsBetweenSamples must be > 0, got $stepsBetweenSamples")
+  require(warmupStepCount >= 0, s"warmupStepCount must be >= 0, got $warmupStepCount")
+  require(samplePoolSize > 0, s"samplePoolSize must be > 0, got $samplePoolSize")
+}

--- a/src/main/scala/thylacine/config/MdsConfig.scala
+++ b/src/main/scala/thylacine/config/MdsConfig.scala
@@ -22,4 +22,14 @@ case class MdsConfig(
   expansionMultiplier: Double,
   contractionMultiplier: Double,
   numberOfPriorSamplesToSetStartingPoint: Option[Int]
-)
+) {
+  require(convergenceThreshold > 0, s"convergenceThreshold must be > 0, got $convergenceThreshold")
+  require(expansionMultiplier > 1, s"expansionMultiplier must be > 1, got $expansionMultiplier")
+  require(
+    contractionMultiplier > 0 && contractionMultiplier < 1,
+    s"contractionMultiplier must be in (0, 1), got $contractionMultiplier"
+  )
+  numberOfPriorSamplesToSetStartingPoint.foreach(n =>
+    require(n > 0, s"numberOfPriorSamplesToSetStartingPoint must be > 0, got $n")
+  )
+}

--- a/src/main/scala/thylacine/config/SlqConfig.scala
+++ b/src/main/scala/thylacine/config/SlqConfig.scala
@@ -25,4 +25,19 @@ case class SlqConfig(
   sampleParallelism: Int,
   maxIterationCount: Int,
   minIterationCount: Int
-)
+) {
+  require(poolSize > 0, s"poolSize must be > 0, got $poolSize")
+  require(abscissaNumber > 0, s"abscissaNumber must be > 0, got $abscissaNumber")
+  require(domainScalingIncrement > 0, s"domainScalingIncrement must be > 0, got $domainScalingIncrement")
+  require(
+    targetAcceptanceProbability > 0 && targetAcceptanceProbability < 1,
+    s"targetAcceptanceProbability must be in (0, 1), got $targetAcceptanceProbability"
+  )
+  require(sampleParallelism > 0, s"sampleParallelism must be > 0, got $sampleParallelism")
+  require(maxIterationCount > 0, s"maxIterationCount must be > 0, got $maxIterationCount")
+  require(minIterationCount > 0, s"minIterationCount must be > 0, got $minIterationCount")
+  require(
+    minIterationCount <= maxIterationCount,
+    s"minIterationCount ($minIterationCount) must be <= maxIterationCount ($maxIterationCount)"
+  )
+}

--- a/src/main/scala/thylacine/model/components/likelihood/GaussianLikelihood.scala
+++ b/src/main/scala/thylacine/model/components/likelihood/GaussianLikelihood.scala
@@ -45,7 +45,11 @@ case class GaussianLikelihood[F[_]: Async, T <: ForwardModel[F]](
     if (validated) {
       this
     } else {
-      this.copy(observations = observations.getValidated, validated = true)
+      this.copy(
+        observations = observations.getValidated,
+        forwardModel = forwardModel.getValidated.asInstanceOf[T],
+        validated    = true
+      )
     }
 
   override private[thylacine] lazy val observationDistribution: GaussianDistribution =

--- a/src/main/scala/thylacine/model/components/likelihood/GaussianLinearLikelihood.scala
+++ b/src/main/scala/thylacine/model/components/likelihood/GaussianLinearLikelihood.scala
@@ -49,7 +49,11 @@ case class GaussianLinearLikelihood[F[_]: Async](
     if (validated) {
       this
     } else {
-      this.copy(observations = observations.getValidated, validated = true)
+      this.copy(
+        observations = observations.getValidated,
+        forwardModel = forwardModel.getValidated,
+        validated    = true
+      )
     }
 
   override private[thylacine] lazy val observationDistribution: GaussianDistribution =

--- a/src/main/scala/thylacine/model/components/likelihood/Likelihood.scala
+++ b/src/main/scala/thylacine/model/components/likelihood/Likelihood.scala
@@ -65,5 +65,6 @@ trait Likelihood[F[_], +FM <: ForwardModel[F], +D <: Distribution]
           VectorContainer(LinearAlgebra.multiplyMV(jacobianTranspose, measGrad.rawVector))
         )
       }
-      .reduce(_.rawMergeWith(_))
+      .reduceOption(_.rawMergeWith(_))
+      .getOrElse(IndexedVectorCollection.empty)
 }

--- a/src/main/scala/thylacine/model/components/likelihood/UniformLikelihood.scala
+++ b/src/main/scala/thylacine/model/components/likelihood/UniformLikelihood.scala
@@ -44,9 +44,10 @@ case class UniformLikelihood[F[_]: Async, T <: ForwardModel[F]](
       this
     } else {
       this.copy(
-        lowerBounds = lowerBounds.getValidated,
-        upperBounds = upperBounds.getValidated,
-        validated   = true
+        lowerBounds  = lowerBounds.getValidated,
+        upperBounds  = upperBounds.getValidated,
+        forwardModel = forwardModel.getValidated.asInstanceOf[T],
+        validated    = true
       )
     }
 

--- a/src/main/scala/thylacine/model/components/posterior/GaussianAnalyticPosterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/GaussianAnalyticPosterior.scala
@@ -201,7 +201,8 @@ object GaussianAnalyticPosterior {
             MatrixContainer.zeros(likelihood.forwardModel.rangeDimension, id._2)
           )
         }
-        .reduce(_.columnMergeWith(_))
+        .reduceOption(_.columnMergeWith(_))
+        .getOrElse(MatrixContainer.zeros(likelihood.forwardModel.rangeDimension, 0))
 
       this.copy(
         data = Some(

--- a/src/main/scala/thylacine/model/components/posterior/Posterior.scala
+++ b/src/main/scala/thylacine/model/components/posterior/Posterior.scala
@@ -22,7 +22,7 @@ import thylacine.model.components.prior.*
 import thylacine.model.core.GenericIdentifier.*
 import thylacine.model.core.*
 import thylacine.model.core.values.IndexedVectorCollection.ModelParameterCollection
-import thylacine.model.core.values.VectorContainer
+import thylacine.model.core.values.{ IndexedVectorCollection, VectorContainer }
 import thylacine.model.core.values.modelparameters.{ ModelParameterPdf, ModelParameterContext }
 
 import cats.syntax.all.*
@@ -64,15 +64,17 @@ private[thylacine] trait Posterior[F[_], P <: Prior[F, ?], L <: Likelihood[F, ?,
       priorSum <-
         priors.toList
           .traverse(_.logPdfGradientAt(input))
-          .map(_.reduce(_.rawSumWith(_)))
+          .map(_.reduceOption(_.rawSumWith(_)).getOrElse(zeroModelParameterCollection))
       likelihoodSum <-
         likelihoods.toList
           .traverse(_.logPdfGradientAt(input))
-          .map(_.reduce(_.rawSumWith(_)))
+          .map(_.reduceOption(_.rawSumWith(_)).getOrElse(zeroModelParameterCollection))
     } yield priorSum.rawSumWith(likelihoodSum)
 
   private[thylacine] def samplePriors: F[ModelParameterCollection] =
-    priors.toVector.traverse(_.sampleModelParameters(1).map(_.head)).map(_.reduce(_.rawMergeWith(_)))
+    priors.toVector
+      .traverse(_.sampleModelParameters(1).map(_.head))
+      .map(_.reduceOption(_.rawMergeWith(_)).getOrElse(IndexedVectorCollection.empty))
 
   override private[thylacine] def logPdfAt(
     input: ModelParameterCollection

--- a/src/main/scala/thylacine/model/core/computation/FiniteDifferenceJacobian.scala
+++ b/src/main/scala/thylacine/model/core/computation/FiniteDifferenceJacobian.scala
@@ -53,7 +53,11 @@ private[thylacine] case class FiniteDifferenceJacobian(
                 .map(k => (k._1, index) -> k._2)
             }
 
-          identifier -> MatrixContainer(gradientComponents.reduce(_ ++ _), currentEvaluation.dimension, nudges.size)
+          identifier -> MatrixContainer(
+            gradientComponents.reduceOption(_ ++ _).getOrElse(Map.empty),
+            currentEvaluation.dimension,
+            nudges.size
+          )
         }
         .toMap
 
@@ -81,7 +85,11 @@ private[thylacine] case class FiniteDifferenceJacobian(
                 .map(k => (k._1, index) -> k._2)
             }
 
-          identifier -> MatrixContainer(gradientComponents.reduce(_ ++ _), rangeDim, nudgePairs.size)
+          identifier -> MatrixContainer(
+            gradientComponents.reduceOption(_ ++ _).getOrElse(Map.empty),
+            rangeDim,
+            nudgePairs.size
+          )
         }
         .toMap
 

--- a/src/main/scala/thylacine/model/core/values/MatrixContainer.scala
+++ b/src/main/scala/thylacine/model/core/values/MatrixContainer.scala
@@ -30,7 +30,7 @@ private[thylacine] case class MatrixContainer(
   validated: Boolean = false
 ) extends Container
     with CanValidate[MatrixContainer] {
-  if (!validated) {
+  if (!validated && values.nonEmpty) {
     require(
       values.keys.map(_._1).max <= rowTotalNumber,
       s"Row index out of bounds: max ${values.keys.map(_._1).max} exceeds $rowTotalNumber"
@@ -135,10 +135,13 @@ private[thylacine] object MatrixContainer {
         )
       }
       ._2
-    MatrixContainer(
-      values            = valueMap,
-      rowTotalNumber    = valueMap.keySet.map(_._1).max,
-      columnTotalNumber = valueMap.keySet.map(_._2).max
-    )
+    if (valueMap.isEmpty)
+      zeros(0, 0)
+    else
+      MatrixContainer(
+        values            = valueMap,
+        rowTotalNumber    = valueMap.keySet.map(_._1).max,
+        columnTotalNumber = valueMap.keySet.map(_._2).max
+      )
   }
 }

--- a/src/main/scala/thylacine/model/core/values/modelparameters/ModelParameterContext.scala
+++ b/src/main/scala/thylacine/model/core/values/modelparameters/ModelParameterContext.scala
@@ -62,7 +62,8 @@ private[thylacine] trait ModelParameterContext {
         input.retrieveIndex(identifier).scalaVector +: current
       }
       .reverse
-      .reduce(_ ++ _)
+      .reduceOption(_ ++ _)
+      .getOrElse(Vector.empty)
 
   final private[thylacine] def modelParameterCollectionToRawVector(
     input: ModelParameterCollection

--- a/src/main/scala/thylacine/model/core/values/modelparameters/ModelParameterPdf.scala
+++ b/src/main/scala/thylacine/model/core/values/modelparameters/ModelParameterPdf.scala
@@ -18,7 +18,7 @@ package ai.entrolution
 package thylacine.model.core.values.modelparameters
 
 import thylacine.model.core.values.IndexedVectorCollection.ModelParameterCollection
-import thylacine.model.core.values.*
+import thylacine.model.core.values.{ IndexedVectorCollection, VectorContainer }
 import thylacine.model.core.{ AsyncImplicits, GenericScalarValuedMapping }
 
 import cats.effect.Async
@@ -61,7 +61,9 @@ private[thylacine] trait ModelParameterPdf[F[_]] extends GenericScalarValuedMapp
                               VectorContainer(finiteDifferenceResults.toVector)
                             )
                           }
-      result <- Async[F].delay(componentResults.reduce(_.rawMergeWith(_)))
+      result <- Async[F].delay(
+                  componentResults.reduceOption(_.rawMergeWith(_)).getOrElse(IndexedVectorCollection.empty)
+                )
     } yield result
 
   // Will work most of the time but will require
@@ -76,7 +78,8 @@ private[thylacine] trait ModelParameterPdf[F[_]] extends GenericScalarValuedMapp
       .map { gl =>
         IndexedVectorCollection(gl._1, VectorContainer(gl._2.rawVector.map(_ * pdf)))
       }
-      .reduce(_.rawMergeWith(_))
+      .reduceOption(_.rawMergeWith(_))
+      .getOrElse(IndexedVectorCollection.empty)
 
   final def logPdfAt(input: Map[String, Vector[Double]]): F[Double] =
     logPdfAt(IndexedVectorCollection(input))

--- a/src/main/scala/thylacine/util/MathOps.scala
+++ b/src/main/scala/thylacine/util/MathOps.scala
@@ -61,13 +61,18 @@ private[thylacine] object MathOps {
         (i.head + j) +: i
       }
 
-    val normalisedCdf = cdfReversed
-      .map(_ / cdfReversed.head)
-      .reverse
+    if (cdfReversed.head == BigDecimal(0)) {
+      val n = values.size
+      (0 until n).map(i => (BigDecimal(i) / BigDecimal(n), BigDecimal(i + 1) / BigDecimal(n))).toVector
+    } else {
+      val normalisedCdf = cdfReversed
+        .map(_ / cdfReversed.head)
+        .reverse
 
-    normalisedCdf
-      .dropRight(1)
-      .zip(normalisedCdf.tail)
+      normalisedCdf
+        .dropRight(1)
+        .zip(normalisedCdf.tail)
+    }
   }
 
   private[thylacine] def vectorCdfStaircase(


### PR DESCRIPTION
## Summary
- Add `require` validation to all 7 config case classes (fail-fast on invalid parameters like negative step sizes, zero thresholds, out-of-range probabilities)
- Replace `.reduce` with `.reduceOption` across 8 call sites in 6 files for defensive robustness against empty collections
- Propagate forward model validation through `getValidated` in `GaussianLikelihood`, `UniformLikelihood`, and `GaussianLinearLikelihood` (consistent with `CauchyLikelihood`)
- Fix `MatrixContainer` constructor and factory crashes on empty values (`.max` on empty keys)
- Fix `MathOps.cdfStaircase` (BigDecimal) missing zero-sum guard
- Update `bengal-stm` from 0.12.0 to 0.13.0
- Bump version to 0.16.0, update CHANGELOG and SECURITY

## Test plan
- [x] All 220 tests pass on Scala 2.13.16
- [x] All 220 tests pass on Scala 3.6.4
- [ ] CI passes on both Scala versions