### PR TITLE
Restrict CI publish to tag pushes only

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -73,15 +73,15 @@ jobs:
         run: sbt '++ ${{ matrix.scala }}' doc
 
       - name: Make target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: mkdir -p target project/target
 
       - name: Compress target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         run: tar cf targets.tar target project/target
 
       - name: Upload target directories
-        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+        if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
         uses: actions/upload-artifact@v5
         with:
           name: target-${{ matrix.os }}-${{ matrix.java }}-${{ matrix.scala }}
@@ -90,7 +90,7 @@ jobs:
   publish:
     name: Publish Artifacts
     needs: [build]
-    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main')
+    if: github.event_name != 'pull_request' && (startsWith(github.ref, 'refs/tags/v'))
     strategy:
       matrix:
         os: [blacksmith-2vcpu-ubuntu-2204]

--- a/build.sbt
+++ b/build.sbt
@@ -12,6 +12,9 @@ ThisBuild / developers ++= List(
 ThisBuild / githubWorkflowJavaVersions := Seq(JavaSpec.temurin("21"))
 ThisBuild / githubWorkflowOSes         := Seq("blacksmith-2vcpu-ubuntu-2204")
 
+// Only publish on tag pushes (not main) to avoid SNAPSHOT publish failures
+ThisBuild / githubWorkflowPublishTargetBranches := Seq(RefPredicate.StartsWith(Ref.Tag("v")))
+
 scalaVersion                    := DependencyVersions.scala2p13Version
 ThisBuild / crossScalaVersions  := Seq(DependencyVersions.scala2p13Version, DependencyVersions.scala3Version)
 ThisBuild / tlVersionIntroduced := Map("2.13" -> "0.16", "3" -> "0.16")


### PR DESCRIPTION
## Summary
- CI badge on main shows as failing because the Publish Artifacts job gets a 403 when publishing SNAPSHOT jars to the Maven snapshots repository
- All tests pass — only the publish step fails
- Restricts `githubWorkflowPublishTargetBranches` to tag pushes only (`v*`), so main branch CI only runs tests
- Release publishing on tag pushes is unaffected (v0.16.0 published successfully)

## Test plan
- [ ] CI passes on this PR (tests, formatting, workflow check)
- [ ] After merge, main branch CI badge turns green
- [ ] Future tag pushes still trigger the publish job